### PR TITLE
CPU refactoring part 1

### DIFF
--- a/BSD/mini_ipmi_bsdcpu.py
+++ b/BSD/mini_ipmi_bsdcpu.py
@@ -22,7 +22,7 @@ TJMAX = '70'
 import sys
 import subprocess
 import re
-from sender_wrapper import (readConfig, processData, fail_ifNot_Py3, removeQuotes)
+from sender_wrapper import (readConfig, processData, fail_ifNot_Py3)
 
 HOST = sys.argv[2]
 

--- a/BSD/mini_ipmi_bsdcpu.py
+++ b/BSD/mini_ipmi_bsdcpu.py
@@ -2,33 +2,36 @@
 
 ## Installation instructions: https://github.com/nobodysu/zabbix-mini-IPMI ##
 
-binPath = r'/sbin/sysctl'
+BIN_PATH = r'/sbin/sysctl'
 
 # path to second send script
-senderPyPath = r'/usr/local/etc/zabbix/scripts/sender_wrapper.py'
+SENDER_WRAPPER_PATH = r'/usr/local/etc/zabbix/scripts/sender_wrapper.py'
 
 # path to zabbix agent configuration file
-agentConf = r'/usr/local/etc/zabbix3/zabbix_agentd.conf'
+AGENT_CONF_PATH = r'/usr/local/etc/zabbix3/zabbix_agentd.conf'
 
-senderPath = r'zabbix_sender'
-#senderPath = r'/usr/bin/zabbix_sender'
+SENDER_PATH = r'zabbix_sender'
+#SENDER_PATH = r'/usr/bin/zabbix_sender'
 
-timeout = '80'         # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
+TIMEOUT = '80'         # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
                        # this setting MUST be lower than 'Update interval' in discovery rule
-tjMax = '85'
+TJMAX = '70'
 
 ## End of configuration ##
 
 import sys
 import subprocess
 import re
-from sender_wrapper import (readConfig, processData, fail_ifNot_Py3)
+from sender_wrapper import (readConfig, processData, fail_ifNot_Py3, removeQuotes)
+
+HOST = sys.argv[2]
 
 
-def getOutput():
+def getOutput(binPath_):
+
     p = None
     try:
-        p = subprocess.check_output([binPath, 'dev.cpu'], universal_newlines=True)
+        p = subprocess.check_output([binPath_, 'dev.cpu'], universal_newlines=True)
     except OSError as e:
         if e.args[0] == 2:
             error = 'OS_NOCMD'
@@ -52,25 +55,25 @@ def getOutput():
     return error, p
 
 
-def getCpuData():
+def getCpuData(pOut_):
     '''Can work unexpectedly with multiple CPUs.'''
     sender = []
     json = []
 
-    temp = re.findall(r'dev\.cpu\.(\d+)\.temperature:\s+(\d+)', pOut, re.I)
-    if temp:
+    tempRe = re.findall(r'dev\.cpu\.(\d+)\.temperature:\s+(\d+)', pOut_, re.I)
+    if tempRe:
         error = None
         json.append({'{#CPU}':'0'})
 
         allTemps = []
-        for i in temp:
-            allTemps.append(i[1])
-            sender.append('%s mini.cpu.temp[cpu0,core%s] "%s"' % (host, i[0], i[1]))
-            json.append({'{#CPUC}':'0', '{#CORE}':i[0]})
+        for num, val in tempRe:
+            allTemps.append(val)
+            sender.append('"%s" mini.cpu.temp[cpu0,core%s] "%s"' % (HOST, num, val))
+            json.append({'{#CPUC}':'0', '{#CORE}':num})
 
-        sender.append('%s mini.cpu.info[cpu0,TjMax] "%s"' % (host, tjMax))
-        sender.append('%s mini.cpu.temp[cpu0,MAX] "%s"' % (host, max(allTemps)))
-        sender.append('%s mini.cpu.temp[MAX] "%s"' % (host, max(allTemps)))
+        sender.append('"%s" mini.cpu.info[cpu0,TjMax] "%s"'   % (HOST, TJMAX))
+        sender.append('"%s" mini.cpu.temp[cpu0,MAX] "%s"'     % (HOST, max(allTemps)))
+        sender.append('"%s" mini.cpu.temp[MAX] "%s"'          % (HOST, max(allTemps)))
 
     else:
         error = 'NOCPUTEMPS'
@@ -79,28 +82,30 @@ def getCpuData():
 
 
 if __name__ == '__main__':
+
     fail_ifNot_Py3()
 
-    host = '"' + sys.argv[2] + '"'   # hostname
     senderData = []
     jsonData = []
 
-    getOutput_Out = getOutput()
+    p_Output = getOutput(BIN_PATH)
+    pRunStatus = p_Output[0]
+    pOut = p_Output[1]
 
-    statusC = None
-    if getOutput_Out[1]:   # process output
-        pOut = getOutput_Out[1]
-
-        getCpuData_Out = getCpuData()
+    errors = None
+    if pOut:
+        getCpuData_Out = getCpuData(pOut)
+        cpuErrors = getCpuData_Out[2]
         senderData.extend(getCpuData_Out[0])
         jsonData.extend(getCpuData_Out[1])
-        if getCpuData_Out[2]:
-            statusC = 'cpu_err'
-            senderData.append('%s mini.cpu.info[ConfigStatus] "%s"' % (host, getCpuData_Out[2]))
+        if cpuErrors:
+            errors = 'cpu_err'
+            senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, cpuErrors))
 
-    if not statusC:
-        senderData.append('%s mini.cpu.info[ConfigStatus] "%s"' % (host, getOutput_Out[0]))   # OS_NOCMD, OS_ERROR, UNKNOWN_EXC_ERROR, CONFIGURED
+    if not errors:
+        senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, pRunStatus))   # OS_NOCMD, OS_ERROR, UNKNOWN_EXC_ERROR, CONFIGURED
 
     link = r'https://github.com/nobodysu/zabbix-mini-IPMI/issues'
-    processData(senderData, jsonData, agentConf, senderPyPath, senderPath, timeout, host, link)
+    sendStatusKey = 'mini.cpu.info[SendStatus]'
+    processData(senderData, jsonData, AGENT_CONF_PATH, SENDER_WRAPPER_PATH, SENDER_PATH, TIMEOUT, HOST, link, sendStatusKey)
 

--- a/BSD/sudoers.d/zabbix
+++ b/BSD/sudoers.d/zabbix
@@ -1,4 +1,4 @@
-#Defaults:zabbix !requiretty   # Uncomment in case of errors
+#Defaults:zabbix !requiretty   # Uncomment in case of sudo errors
 
 zabbix	ALL=NOPASSWD:	/usr/local/etc/zabbix/scripts/mini_ipmi_smartctl.py
 

--- a/BSD/sudoers.d/zabbix
+++ b/BSD/sudoers.d/zabbix
@@ -1,5 +1,4 @@
-Defaults:zabbix !requiretty
-Cmnd_Alias ZABBIX_CMD = /usr/local/etc/zabbix/scripts/mini_ipmi_smartctl.py
+#Defaults:zabbix !requiretty   # Uncomment in case of errors
 
-zabbix   ALL = (other_user)  NOPASSWD: ALL
-zabbix   ALL = (root)        NOPASSWD: ZABBIX_CMD
+zabbix	ALL=NOPASSWD:	/usr/local/etc/zabbix/scripts/mini_ipmi_smartctl.py
+

--- a/Linux/mini_ipmi_lmsensors.py
+++ b/Linux/mini_ipmi_lmsensors.py
@@ -16,12 +16,12 @@ SENDER_PATH = r'zabbix_sender'
 
 FALLBACK_TJMAX = '70'
 
-# Following settings brings (almost) no overhead. Use 'no' to disable unneeded data.
-GATHER_VOLTAGES     = 'yes'
-GATHER_BOARD_FANS   = 'yes'
-GATHER_BOARD_TEMPS  = 'yes'
-GATHER_GPU_DATA     = 'yes'
-GATHER_CPU_DATA     = 'yes'
+# Following settings brings (almost) no overhead. True or False
+GATHER_VOLTAGES     = True
+GATHER_BOARD_FANS   = True
+GATHER_BOARD_TEMPS  = True
+GATHER_GPU_DATA     = True
+GATHER_CPU_DATA     = True
 
 VOLTAGE_REGEXPS_KEYS_AND_JSONS = (
     ('Vcore',                               'cpuVcore', '{#VCORE}'),
@@ -269,22 +269,22 @@ if __name__ == '__main__':
     pOut = p_Output[1]
 
     if pOut:
-        if GATHER_VOLTAGES == 'yes':
+        if GATHER_VOLTAGES:
             getVoltages_Out = getVoltages(pOut)
             senderData.extend(getVoltages_Out[0])
             jsonData.extend(getVoltages_Out[1])
 
-        if GATHER_BOARD_FANS == 'yes':
+        if GATHER_BOARD_FANS:
             getBoardFans_Out = getBoardFans(pOut)
             senderData.extend(getBoardFans_Out[0])
             jsonData.extend(getBoardFans_Out[1])
 
-        if GATHER_BOARD_TEMPS == 'yes':
+        if GATHER_BOARD_TEMPS:
             getBoardTemps_Out = getBoardTemps(pOut)
             senderData.extend(getBoardTemps_Out[0])
             jsonData.extend(getBoardTemps_Out[1])
 
-        if GATHER_GPU_DATA == 'yes':
+        if GATHER_GPU_DATA:
             getGpuData_Out = getGpuData(pOut)
             gpuErrors = getGpuData_Out[2]
             senderData.extend(getGpuData_Out[0])
@@ -292,7 +292,7 @@ if __name__ == '__main__':
             if gpuErrors:
                 statusErrors.append(gpuErrors)   # NOGPUS, NOGPUTEMPS
 
-        if GATHER_CPU_DATA == 'yes':
+        if GATHER_CPU_DATA:
             getCpuData_Out = getCpuData(pOut)
             cpuErrors = getCpuData_Out[2]
             senderData.extend(getCpuData_Out[0])

--- a/Linux/mini_ipmi_lmsensors.py
+++ b/Linux/mini_ipmi_lmsensors.py
@@ -85,10 +85,11 @@ def getOutput(binPath_):
     else:
         error = 'CONFIGURED'
 
-    pSplit = p.strip()
-    pSplit = pSplit.split('\n\n')
+    if p:
+        p = p.strip()
+        p = p.split('\n\n')
 
-    return error, pSplit
+    return error, p
 
 
 def getVoltages(pOut_):

--- a/Linux/mini_ipmi_lmsensors.py
+++ b/Linux/mini_ipmi_lmsensors.py
@@ -2,40 +2,60 @@
 
 ## Installation instructions: https://github.com/nobodysu/zabbix-mini-IPMI ##
 
-binPath = r'sensors'
-#binPath = r'/usr/bin/sensors'   # if 'sensors' isn't in PATH
+BIN_PATH = r'sensors'   # -u
+#BIN_PATH = r'/usr/bin/sensors'   # if 'sensors' isn't in PATH
 
 # path to second send script
-senderPyPath = r'/etc/zabbix/scripts/sender_wrapper.py'
+SENDER_WRAPPER_PATH = r'/etc/zabbix/scripts/sender_wrapper.py'
 
 # path to zabbix agent configuration file
-agentConf = r'/etc/zabbix/zabbix_agentd.conf'
+AGENT_CONF_PATH = r'/etc/zabbix/zabbix_agentd.conf'
 
-senderPath = r'zabbix_sender'
-#senderPath = r'/usr/bin/zabbix_sender'
+SENDER_PATH = r'zabbix_sender'
+#SENDER_PATH = r'/usr/bin/zabbix_sender'
 
-timeout = '80'         # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
-                       # this setting MUST be lower than 'Update interval' in discovery rule
-fallbackTjMax = '85'
-fallbackVcore = '1.35'
-fallbackVtt = '1.1'
+FALLBACK_TJMAX = '70'
 
 # Following settings brings (almost) no overhead. Use 'no' to disable unneeded data.
-gatherVoltages = 'yes'
-gatherBoardFans = 'yes'
-gatherBoardTemp = 'yes'
-gatherGpuData = 'yes'
-gatherCpuData = 'yes'
+GATHER_VOLTAGES     = 'yes'
+GATHER_BOARD_FANS   = 'yes'
+GATHER_BOARD_TEMPS  = 'yes'
+GATHER_GPU_DATA     = 'yes'
+GATHER_CPU_DATA     = 'yes'
+
+VOLTAGE_REGEXPS_KEYS_AND_JSONS = (
+    ('Vcore',                               'cpuVcore', '{#VCORE}'),
+    ('VBAT',                                'VBat',     '{#VBAT}'),
+    ('3VSB|VSB3V|Standby \+3\.3V|3V_SB',    'VSB3V',    '{#VSB3V}'),
+    ('3VCC|VCC3V',                          'VCC3V',    '{#VCC3V}'),
+    ('AVCC',                                'AVCC',     '{#AVCC}'),
+    ('VTT',                                 'VTT',      '{#VTT}'),
+    ('\+3\.3 Voltage',                      'p3.3V',    '{#p3.3V}'),
+    ('\+5 Voltage',                         'p5V',      '{#p5V}'),
+    ('\+12 Voltage',                        'p12V',     '{#p12V}'),
+)
+
+# re.I | re.M
+CORES_REGEXPS = (
+    ('Core(?:\s+)?(\d+):\n\s+temp\d+_input:\s+(\d+)'),
+    ('Core(\d+)\s+Temp:\n\s+temp\d+_input:\s+(\d+)'),
+    ('Tdie:\n\s+temp(\d+)_input:\s+(\d+)'),
+)
+
+TIMEOUT = '80'         # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
+                       # this setting MUST be lower than 'Update interval' in discovery rule
 
 ## End of configuration ##
 
 import sys
 import subprocess
 import re
-from sender_wrapper import (readConfig, processData, fail_ifNot_Py3)
+from sender_wrapper import (readConfig, processData, fail_ifNot_Py3, removeQuotes)
 
-
-def getOutput():
+HOST = sys.argv[2]
+    
+    
+def getOutput(binPath_):
     try:
         from subprocess import DEVNULL   # for python versions greater than 3.3, inclusive
     except:
@@ -44,7 +64,7 @@ def getOutput():
 
     p = None
     try:
-        p = subprocess.check_output([binPath, '-u'], universal_newlines=True, stderr=DEVNULL)
+        p = subprocess.check_output([binPath_, '-u'], universal_newlines=True, stderr=DEVNULL)
     except OSError as e:
         if e.args[0] == 2:
             error = 'OS_NOCMD'
@@ -67,143 +87,102 @@ def getOutput():
 
     pSplit = p.strip()
     pSplit = pSplit.split('\n\n')
-#    for i in pSplit: print(i, '\n')   # DEBUG
 
     return error, pSplit
 
 
-def getVoltages():
+def getVoltages(pOut_):
     sender = []
     json = []
 
-    for v in pOut:
-        if 'Adapter: PCI adapter' in v:   # we dont need GPU voltages
+    for block in pOut_:
+        if 'Adapter: PCI adapter' in block:   # we dont need GPU voltages
             continue
 
-        voltage = re.findall(r'(.+):\n(?:\s+)?in(\d+)_input:\s+(\d+\.\d+)', v, re.I)
-        if voltage:
-            for i in voltage:
-                if re.search('Vcore', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[cpuVcore] "%s"' % (host, i[2]))
-                    json.append({'{#VCORE}':'cpuVcore'})   # hardcoded because of zabbix stubbornness
-
-                    vcoreRe = re.search('in' + i[1] + r'_max:\s+(\d+\.\d+)', v, re.I)
-                    if vcoreRe:
-                        vcore = vcoreRe.group(1)
-                    else:
-                        vcore = fallbackVcore
-
-                    sender.append('%s mini.brd.info[vcoreMax] "%s"' % (host, vcore))
-    
-                elif re.search('VBAT', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[VBat] "%s"' % (host, i[2]))
-                    json.append({'{#VBAT}':'VBat'})
+        voltagesRe = re.findall(r'(.+):\n(?:\s+)?in(\d+)_input:\s+(\d+\.\d+)', block, re.I)
+        if voltagesRe:
+            for name, num, val in voltagesRe:
+            
+                for regexp, key, jsn in VOLTAGE_REGEXPS_KEYS_AND_JSONS:
+                    if re.search(regexp, name, re.I):
+                        sender.append('"%s" mini.brd.vlt[%s] "%s"' % (HOST, key, removeQuotes(val)))
+                        json.append({jsn:key})
  
-                elif re.search('3VSB|VSB3V|Standby \+3\.3V|3V_SB', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[VSB3V] "%s"' % (host, i[2]))
-                    json.append({'{#VSB3V}':'VSB3V'})
- 
-                elif re.search('3VCC|VCC3V', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[VCC3V] "%s"' % (host, i[2]))
-                    json.append({'{#VCC3V}':'VCC3V'})
-        
-                elif re.search('AVCC', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[AVCC] "%s"' % (host, i[2]))
-                    json.append({'{#VAVCC}':'AVCC'})
-        
-                elif re.search('VTT', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[VTT] "%s"' % (host, i[2]))
-                    json.append({'{#VTT}':'VTT'})
-     
-                    vttRe = re.search('in' + i[1] + r'_max:\s+(\d+\.\d+)', v, re.I)
-                    if vttRe:
-                        vtt = vttRe.group(1)
-                    else:
-                        vtt = fallbackVtt
-
-                    sender.append('%s mini.brd.info[vttMax] "%s"' % (host, vtt))
- 
-                elif re.search('\+3\.3 Voltage', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[p3.3V] "%s"' % (host, i[2]))
-                    json.append({'{#P33V}':'p3.3V'})
-     
-                elif re.search('\+5 Voltage', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[p5V] "%s"' % (host, i[2]))
-                    json.append({'{#P5V}':'p5V'})
-     
-                elif re.search('\+12 Voltage', i[0], re.I):
-                    sender.append('%s mini.brd.vlt[p12V] "%s"' % (host, i[2]))
-                    json.append({'{#P12V}':'p12V'})
- 
-                sender.append('%s mini.brd.vlt[%s] "%s"' % (host, i[1], i[2]))   # static items for graph, could be duplicate
+                sender.append('"%s" mini.brd.vlt[%s] "%s"' % (HOST, num, removeQuotes(val)))   # static items for graph, could be duplicate
 
             break   # as safe as possible
 
     return sender, json
 
 
-def getBoardFans():
+def getBoardFans(pOut_):
+
     sender = []
     json = []
 
-    for i in pOut:
+    for i in pOut_:
         if 'Adapter: PCI adapter' in i:   # we dont need GPU fans
             continue
  
         fans = re.findall(r'(.+):\n(?:\s+)?fan(\d+)_input:\s+(\d+)', i, re.I)
         if fans:
-            for f in fans:
+            for name, num, val in fans:
                 # only create LLD when speed is not zero, BUT always send values including zero (prevents false triggering)
-                sender.append('%s mini.brd.fan[%s,rpm] "%s"' % (host, f[1], f[2]))
-                if f[2] != '0':
-                    json.append({'{#BRDFANNAME}':f[0].strip(), '{#BRDFANNUM}':f[1]})
+                sender.append('"%s" mini.brd.fan[%s,rpm] "%s"' % (HOST, num, val))
+                if val != '0':
+                    json.append({'{#BRDFANNAME}':name.strip(), '{#BRDFANNUM}':num})
  
             break
 
     return sender, json
 
 
-def getBoardTemp():
+def getBoardTemps(pOut_):
+
     sender = []
     json = []
 
-    for i in pOut:
+    for i in pOut_:
         if 'Adapter: PCI adapter' in i:   # we dont need GPU temps
             continue
  
         temps = re.findall(r'((?:CPU|GPU|MB|M/B|AUX|Ambient|Other|SYS|Processor).+):\n(?:\s+)?temp(\d+)_input:\s+(\d+)', i, re.I)
         if temps:
-            for t in temps:
-                sender.append('%s mini.brd.temp[%s] "%s"' % (host, t[1], t[2]))
-                json.append({'{#BRDTEMPNAME}':t[0].strip(), '{#BRDTEMPNUM}':t[1]})
+            for name, num, val in temps:
+                sender.append('"%s" mini.brd.temp[%s] "%s"' % (HOST, num, val))
+                json.append({'{#BRDTEMPNAME}':name.strip(), '{#BRDTEMPNUM}':num})
 
             break
 
     return sender, json
 
 
-def getGpuData():
+def getGpuData(pOut_):
+
     sender = []
     json = []
 
     gpuBlocks = -1
     allTemps = []
-    for i in pOut:
+    for i in pOut_:
         temp = re.search(r'(nouveau.+|nvidia.+)\n.+\n.+\n(?:\s+)?temp\d+_input:\s+(\d+)', i, re.I)
         if temp:
+            gpuid = temp.group(1)
+            val = temp.group(2)
+
             gpuBlocks += 1
-            allTemps.append(int(temp.group(2)))
+            allTemps.append(int(val))
 
             json.append({'{#GPU}':gpuBlocks})
-            sender.append('%s mini.gpu.info[gpu%s,ID] "%s"' % (host, gpuBlocks, temp.group(1)))
+            sender.append('"%s" mini.gpu.info[gpu%s,ID] "%s"' % (HOST, gpuBlocks, removeQuotes(gpuid)))
 
             json.append({'{#GPUTEMP}':gpuBlocks})
-            sender.append('%s mini.gpu.temp[gpu%s] "%s"' % (host, gpuBlocks, temp.group(2)))
+            sender.append('"%s" mini.gpu.temp[gpu%s] "%s"' % (HOST, gpuBlocks, val))
 
     if gpuBlocks != -1:
         if allTemps:
             error = None
-            sender.append('%s mini.gpu.temp[MAX] "%s"' % (host, max(allTemps)))
+            sender.append('"%s" mini.gpu.temp[MAX] "%s"' % (HOST, max(allTemps)))
         else:
             error = 'NOGPUTEMPS'   # unreachable
     else:
@@ -212,48 +191,63 @@ def getGpuData():
     return sender, json, error
 
 
-def getCpuData():
+def chooseCpuRegexp(block_):
+
+    result = ''
+    for regexp in CORES_REGEXPS:
+        match = re.search(regexp, block_, re.I | re.M)
+        if match:
+            result = regexp
+
+    return result
+
+
+def getCpuData(pOut_):
     '''Note: certain cores can pose as different blocks making them separate cpus in zabbix.'''
     sender = []
     json = []
 
     cpuBlocks = -1   # first cpu will be '0'
     allTemps = []
-    for i in pOut:   # for each block in output
+    for block in pOut_:
+        regexp = chooseCpuRegexp(block)
 
-        coreTempsRe = re.findall(r'Core(?:\s+)?(\d+)(?:\s+Temp)?:\n.+_input:\s+(\d+)', i, re.I | re.M)
-        if coreTempsRe:
+        coreTempsRe = re.findall(regexp, block, re.I | re.M)
+
+        if (coreTempsRe and
+            regexp):
+
             cpuBlocks += 1   # you need to be creative to parse lmsensors
 
             json.append({'{#CPU}':cpuBlocks})
-            sender.append('%s mini.cpu.info[cpu%s,ID] "%s"' % (host, cpuBlocks, i.splitlines()[0]))
+            sender.append('"%s" mini.cpu.info[cpu%s,ID] "%s"' % (HOST, cpuBlocks, removeQuotes(block.splitlines()[0])))
 
-            tempCrit = re.search(r'_crit:\s+(\d+)\.\d+', i, re.I)
+            tempCrit = re.search(r'_crit:\s+(\d+)\.\d+', block, re.I)
             if tempCrit:
                 tjMax = tempCrit.group(1)
             else:
-                tjMax = fallbackTjMax
+                tjMax = FALLBACK_TJMAX
 
-            sender.append('%s mini.cpu.info[cpu%s,TjMax] "%s"' % (host, cpuBlocks, tjMax))
+            sender.append('"%s" mini.cpu.info[cpu%s,TjMax] "%s"' % (HOST, cpuBlocks, tjMax))
 
-            previousCore = None
             cpuTemps = []
-            for c in coreTempsRe:
-                if previousCore == c[0]:
+            previousCore = None
+            for num, val in coreTempsRe:
+                if previousCore == num:
                     continue   # some cores have same number - ignore them
-                previousCore = c[0]
+                previousCore = num
 
-                cpuTemps.append(int(c[1]))
-                allTemps.append(int(c[1]))
-                sender.append('%s mini.cpu.temp[cpu%s,core%s] "%s"' % (host, cpuBlocks, c[0], c[1]))
-                json.append({'{#CPUC}':cpuBlocks, '{#CORE}':c[0]})
+                cpuTemps.append(int(val))
+                allTemps.append(int(val))
+                sender.append('"%s" mini.cpu.temp[cpu%s,core%s] "%s"' % (HOST, cpuBlocks, num, val))
+                json.append({'{#CPUC}':cpuBlocks, '{#CORE}':num})
 
-            sender.append('%s mini.cpu.temp[cpu%s,MAX] "%s"' % (host, cpuBlocks, max(cpuTemps)))
+            sender.append('"%s" mini.cpu.temp[cpu%s,MAX] "%s"' % (HOST, cpuBlocks, max(cpuTemps)))
 
     if cpuBlocks != -1:
         if allTemps:
             error = None
-            sender.append('%s mini.cpu.temp[MAX] "%s"' % (host, max(allTemps)))
+            sender.append('"%s" mini.cpu.temp[MAX] "%s"' % (HOST, max(allTemps)))
         else:
             error = 'NOCPUTEMPS'
     else:
@@ -263,52 +257,56 @@ def getCpuData():
 
 
 if __name__ == '__main__':
+
     fail_ifNot_Py3()
 
-    host = '"' + sys.argv[2] + '"'   # hostname
     senderData = []
     jsonData = []
+    statusErrors = []
 
-    getOutput_Out = getOutput()
+    p_Output = getOutput(BIN_PATH)
+    pRunStatus = p_Output[0]
+    pOut = p_Output[1]
 
-    statusC = None
-    if getOutput_Out[1]:   # process output
-        pOut = getOutput_Out[1]
-
-        if gatherVoltages == 'yes':
-            getVoltages_Out = getVoltages()
+    if pOut:
+        if GATHER_VOLTAGES == 'yes':
+            getVoltages_Out = getVoltages(pOut)
             senderData.extend(getVoltages_Out[0])
             jsonData.extend(getVoltages_Out[1])
 
-        if gatherBoardFans == 'yes':
-            getBoardFans_Out = getBoardFans()
+        if GATHER_BOARD_FANS == 'yes':
+            getBoardFans_Out = getBoardFans(pOut)
             senderData.extend(getBoardFans_Out[0])
             jsonData.extend(getBoardFans_Out[1])
 
-        if gatherBoardTemp == 'yes':
-            getBoardTemp_Out = getBoardTemp()
-            senderData.extend(getBoardTemp_Out[0])
-            jsonData.extend(getBoardTemp_Out[1])
+        if GATHER_BOARD_TEMPS == 'yes':
+            getBoardTemps_Out = getBoardTemps(pOut)
+            senderData.extend(getBoardTemps_Out[0])
+            jsonData.extend(getBoardTemps_Out[1])
 
-        if gatherGpuData == 'yes':
-            getGpuData_Out = getGpuData()
+        if GATHER_GPU_DATA == 'yes':
+            getGpuData_Out = getGpuData(pOut)
+            gpuErrors = getGpuData_Out[2]
             senderData.extend(getGpuData_Out[0])
             jsonData.extend(getGpuData_Out[1])
-            if getGpuData_Out[2]:
-                statusC = 'gpu_err'
-                # mini.cpu.info[ConfigStatus] is used to track configuration states including cpu and gpu:
-                senderData.append(host + ' mini.cpu.info[ConfigStatus] "' + getGpuData_Out[2] + '"')   # NOGPUS, NOGPUTEMPS
+            if gpuErrors:
+                statusErrors.append(gpuErrors)   # NOGPUS, NOGPUTEMPS
 
-        if gatherCpuData == 'yes':
-            getCpuData_Out = getCpuData()
+        if GATHER_CPU_DATA == 'yes':
+            getCpuData_Out = getCpuData(pOut)
+            cpuErrors = getCpuData_Out[2]
             senderData.extend(getCpuData_Out[0])
             jsonData.extend(getCpuData_Out[1])
-            if getCpuData_Out[2]:
-                statusC = 'cpu_err'
-                senderData.append('%s mini.cpu.info[ConfigStatus] "%s"' % (host, getCpuData_Out[2]))   # NOCPUS, NOCPUTEMPS
+            if cpuErrors:
+                statusErrors.append(cpuErrors)   # NOCPUS, NOCPUTEMPS
 
-    if not statusC:
-        senderData.append('%s mini.cpu.info[ConfigStatus] "%s"' % (host, getOutput_Out[0]))   # OS_NOCMD, OS_ERROR, UNKNOWN_EXC_ERROR, CONFIGURED
+    if statusErrors:
+        errorsString = ', '.join(statusErrors).strip()
+        senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, errorsString))
+    else:
+        senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, pRunStatus))   # OS_NOCMD, OS_ERROR, UNKNOWN_EXC_ERROR, CONFIGURED
 
     link = r'https://github.com/nobodysu/zabbix-mini-IPMI/issues'
-    processData(senderData, jsonData, agentConf, senderPyPath, senderPath, timeout, host, link)
+    sendStatusKey = 'mini.cpu.info[SendStatus]'
+    processData(senderData, jsonData, AGENT_CONF_PATH, SENDER_WRAPPER_PATH, SENDER_PATH, TIMEOUT, HOST, link, sendStatusKey)
+

--- a/Linux/sudoers.d/zabbix
+++ b/Linux/sudoers.d/zabbix
@@ -1,4 +1,4 @@
-#Defaults:zabbix !requiretty   # Uncomment in case of errors
+#Defaults:zabbix !requiretty   # Uncomment in case of sudo errors
 
 zabbix	ALL=NOPASSWD:	/etc/zabbix/scripts/mini_ipmi_smartctl.py
 

--- a/Linux/sudoers.d/zabbix
+++ b/Linux/sudoers.d/zabbix
@@ -1,4 +1,4 @@
-Defaults:zabbix !requiretty
-Cmnd_Alias ZABBIX_CMD = /etc/zabbix/scripts/mini_ipmi_smartctl.py
-zabbix   ALL = (other_user)  NOPASSWD: ALL
-zabbix   ALL = (root)        NOPASSWD: ZABBIX_CMD
+#Defaults:zabbix !requiretty   # Uncomment in case of errors
+
+zabbix	ALL=NOPASSWD:	/etc/zabbix/scripts/mini_ipmi_smartctl.py
+

--- a/Template_mini-IPMI_v2.xml
+++ b/Template_mini-IPMI_v2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>2.0</version>
-    <date>2019-07-01T13:03:30Z</date>
+    <version>3.0</version>
+    <date>2019-12-03T15:10:42Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -28,73 +28,27 @@
                     <name>mini-IPMI: Temperature</name>
                 </application>
                 <application>
-                    <name>mini-IPMI: Temperature thresholds</name>
+                    <name>mini-IPMI: Thresholds</name>
                 </application>
                 <application>
                     <name>mini-IPMI: Voltage</name>
                 </application>
-                <application>
-                    <name>mini-IPMI: Voltage thresholds</name>
-                </application>
             </applications>
             <items>
                 <item>
-                    <name>All CPUs maximum temperature</name>
+                    <name>BIOS Vendor</name>
                     <type>2</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>mini.cpu.temp[MAX]</key>
+                    <key>mini.brd.info[BIOSvendor]</key>
                     <delay>0</delay>
                     <history>90</history>
-                    <trends>365</trends>
+                    <trends>0</trends>
                     <status>0</status>
-                    <value_type>3</value_type>
+                    <value_type>2</value_type>
                     <allowed_hosts/>
-                    <units>C</units>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>Among all processors and its cores.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Temperature</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>All DISKs maximum temperature</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.disk.temp[MAX]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units>C</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
@@ -118,26 +72,26 @@
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
-                            <name>mini-IPMI: Temperature</name>
+                            <name>mini-IPMI: Info</name>
                         </application>
                     </applications>
                     <valuemap/>
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>All GPUs maximum temperature</name>
+                    <name>BIOS Version</name>
                     <type>2</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>mini.gpu.temp[MAX]</key>
+                    <key>mini.brd.info[BIOSversion]</key>
                     <delay>0</delay>
                     <history>90</history>
-                    <trends>365</trends>
+                    <trends>0</trends>
                     <status>0</status>
-                    <value_type>3</value_type>
+                    <value_type>2</value_type>
                     <allowed_hosts/>
-                    <units>C</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
@@ -157,11 +111,183 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description>Among all cards and its cores.</description>
+                    <description/>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
-                            <name>mini-IPMI: Temperature</name>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>Mainboard Manufacturer</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.brd.info[MainboardManufacturer]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>Mainboard Name</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.brd.info[MainboardName]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>Mainboard Version</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.brd.info[MainboardVersion]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>SMBIOS Version</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.brd.info[SMBIOSversion]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
                         </application>
                     </applications>
                     <valuemap/>
@@ -205,567 +331,6 @@
                     <applications>
                         <application>
                             <name>mini-IPMI: Temperature</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>BIOS Vendor</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[BIOSvendor]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>BIOS Version</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[BIOSversion]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>CPU temperature configuration status</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.cpu.info[ConfigStatus]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>In some cases it could also mean GPU temperature, system voltage and fan speed.&#13;
-&#13;
-Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>DISK heavy debug</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.disk.HeavyDebug</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>DISK last failed send status</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.disk.info[SendStatus]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>DISK temperature configuration status</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.disk.info[ConfigStatus]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>Refers to mini_ipmi_smartctl.py.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>Mainboard Manufacturer</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[MainboardManufacturer]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>Mainboard Name</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[MainboardName]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>Mainboard Version</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[MainboardVersion]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>Maximum VCore voltage</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[vcoreMax]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>0</value_type>
-                    <allowed_hosts/>
-                    <units>V</units>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Voltage thresholds</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>Maximum VTT voltage</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[vttMax]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>0</value_type>
-                    <allowed_hosts/>
-                    <units>V</units>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Voltage thresholds</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>OpenHardwareMonitorReport version</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.info[OHMRver]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>SMBIOS Version</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mini.brd.info[SMBIOSversion]</key>
-                    <delay>0</delay>
-                    <history>90</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>2</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>mini-IPMI: Info</name>
                         </application>
                     </applications>
                     <valuemap/>
@@ -1416,10 +981,399 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                     <valuemap/>
                     <logtimefmt/>
                 </item>
+                <item>
+                    <name>CPU temperature configuration status</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.cpu.info[ConfigStatus]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>In some cases it could also mean GPU temperature, system voltage and fan speed.&#13;
+&#13;
+Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>CPU last failed send status</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.cpu.info[SendStatus]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>All CPUs maximum temperature</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.cpu.temp[MAX]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>C</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>Among all processors and its cores.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Temperature</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>DISK heavy debug</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.disk.HeavyDebug</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>DISK temperature configuration status</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.disk.info[ConfigStatus]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>Refers to mini_ipmi_smartctl.py.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>DISK last failed send status</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.disk.info[SendStatus]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>All DISKs maximum temperature</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.disk.temp[MAX]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>C</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Temperature</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>All GPUs maximum temperature</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.gpu.temp[MAX]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>C</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>Among all cards and its cores.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Temperature</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>OpenHardwareMonitorReport version</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mini.info[OHMRversion]</key>
+                    <delay>0</delay>
+                    <history>90</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>2</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>mini-IPMI: Info</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
             </items>
             <discovery_rules>
                 <discovery_rule>
-                    <name>CPU temperature discovery</name>
+                    <name>CPU discovery</name>
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
@@ -1451,522 +1405,6 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                     <lifetime>1</lifetime>
                     <description/>
                     <item_prototypes>
-                        <item_prototype>
-                            <name>cpu{#CPUC},core{#CORE}: Temperature</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.cpu.temp[cpu{#CPUC},core{#CORE}]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Temperature</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>cpu{#CPU}: ID</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.cpu.info[cpu{#CPU},ID]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>CPU model or ID.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>cpu{#CPU}: Maximum temperature</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.cpu.temp[cpu{#CPU},MAX]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Temperature</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>cpu{#CPU}: Status</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.cpu.info[cpu{#CPU},CPUstatus]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>cpu{#CPU}: TjMax</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.cpu.info[cpu{#CPU},TjMax]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPUFAN}: Fan speed</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.fan[gpu{#GPUFAN},rpm]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>RPM</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Fan speed</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPUMEM}: GPU Memory Free</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.memory[gpu{#GPUMEM},free]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>Mb</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPUMEM}: GPU Memory Total</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.memory[gpu{#GPUMEM},total]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>Mb</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPUMEM}: GPU Memory Used</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.memory[gpu{#GPUMEM},used]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>Mb</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPUTEMP}: Temperature</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.temp[gpu{#GPUTEMP}]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Temperature</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPU}: ID</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.info[gpu{#GPU},ID]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>GPU model or ID.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>gpu{#GPU}: Status</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.gpu.info[gpu{#GPU},GPUstatus]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
                         <item_prototype>
                             <name>Motherboard fan speed: {#BRDFANNAME}</name>
                             <type>2</type>
@@ -2009,6 +1447,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Motherboard temperature: {#BRDTEMPNAME}</name>
@@ -2052,6 +1491,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#P5V}</name>
@@ -2095,6 +1535,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#P12V}</name>
@@ -2138,6 +1579,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#P33V}</name>
@@ -2181,6 +1623,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VAVCC}</name>
@@ -2224,6 +1667,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VBAT}</name>
@@ -2267,6 +1711,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VCC3V}</name>
@@ -2310,6 +1755,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VCORE}</name>
@@ -2353,6 +1799,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VSB3V}</name>
@@ -2396,6 +1843,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Voltage: {#VTT}</name>
@@ -2439,54 +1887,598 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>cpu{#CPU}: Status</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.cpu.info[cpu{#CPU},CPUstatus]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>2</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>cpu{#CPU}: ID</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.cpu.info[cpu{#CPU},ID]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>2</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>CPU model or ID.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>cpu{#CPU}: TjMax</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.cpu.info[cpu{#CPU},TjMax]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Thresholds</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>cpu{#CPUC},core{#CORE}: Temperature</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.cpu.temp[cpu{#CPUC},core{#CORE}]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Temperature</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>cpu{#CPU}: Maximum temperature</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.cpu.temp[cpu{#CPU},MAX]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Temperature</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPUFAN}: Fan speed</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.fan[gpu{#GPUFAN},rpm]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>RPM</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Fan speed</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPU}: Status</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.info[gpu{#GPU},GPUstatus]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>2</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPU}: ID</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.info[gpu{#GPU},ID]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>2</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>GPU model or ID.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPUMEM}: GPU Memory Free</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.memory[gpu{#GPUMEM},free]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>Mb</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPUMEM}: GPU Memory Total</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.memory[gpu{#GPUMEM},total]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>Mb</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPUMEM}: GPU Memory Used</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.memory[gpu{#GPUMEM},used]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>Mb</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>gpu{#GPUTEMP}: Temperature</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.gpu.temp[gpu{#GPUTEMP}]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Temperature</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},ID].diff()}&gt;0</expression>
-                            <name>cpu{#CPU}: CPU model or ID was changed</name>
+                            <name>cpu{#CPU}: CPU model was changed</name>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].last(500)} &gt; {Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},TjMax].last()}</expression>
-                            <name>cpu{#CPU}: is throttling right now: {ITEM.LASTVALUE}</name>
+                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].last()} &gt; {Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},TjMax].last()}</expression>
+                            <name>cpu{#CPU}: is throttling right now</name>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
-                            <description>(depending on values from last 500 seconds)</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},CPUstatus].str(NO_TEMP,#3)}=1 and&#13;
-{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUTEMPS,#3)}=0</expression>
+                            <expression>{Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},CPUstatus].str(NO_TEMP)}=1 and&#13;
+{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUTEMPS)}=0</expression>
                             <name>cpu{#CPU}: no temperature info was found on CPU</name>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
-                            <description>Prevent multiple reporting.</description>
+                            <description>Take a look at CPUS_WITHOUT_SENSOR variable in the script and please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].last(500)}&gt;60</expression>
-                            <name>cpu{#CPU}: temperature is too high: {ITEM.LASTVALUE}</name>
+                            <expression>{Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},CPUstatus].str(NO_SENSOR)}=1</expression>
+                            <name>cpu{#CPU}: no temperature sensor was found on CPU</name>
+                            <url/>
+                            <status>1</status>
+                            <priority>1</priority>
+                            <description/>
+                            <type>0</type>
+                            <dependencies/>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].last()}&gt;{$CPU.HIGH.TEMP}</expression>
+                            <name>cpu{#CPU}: temperature is too high (over {$CPU.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description>(depending on values from last 500 seconds)</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].max(24h)}&gt;60</expression>
-                            <name>cpu{#CPU}: temperature was too high within past 24 hours</name>
+                            <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].max(24h)}&gt;{$CPU.HIGH.TEMP}</expression>
+                            <name>cpu{#CPU}: temperature was too high within past 24 hours (over {$CPU.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.cpu.temp[cpu{#CPU},MAX].max(24h)} &gt; {Template mini-IPMI v2:mini.cpu.info[cpu{#CPU},TjMax].last()}</expression>
@@ -2496,114 +2488,127 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.fan[gpu{#GPUFAN},rpm].last(500)}&lt;600</expression>
-                            <name>gpu{#GPUFAN}: fan speed is too low</name>
+                            <expression>{Template mini-IPMI v2:mini.gpu.fan[gpu{#GPUFAN},rpm].last()}&lt;{$GPU.FAN.MIN.RPM}</expression>
+                            <name>gpu{#GPUFAN}: fan speed is too low (below {$GPU.FAN.MIN.RPM} RPM)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
-                            <description>Known false positives (zero speed).</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.memory[gpu{#GPUMEM},free].last()}&lt;32</expression>
-                            <name>gpu{#GPUMEM}: free video memory is less than 32Mb</name>
+                            <expression>{Template mini-IPMI v2:mini.gpu.memory[gpu{#GPUMEM},free].last()}&lt;{$GPU.MIN.MEM.MB}</expression>
+                            <name>gpu{#GPUMEM}: free video memory is too low (below {$GPU.MIN.MEM.MB} Mb)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.temp[gpu{#GPUTEMP}].last(500)}&gt;70</expression>
-                            <name>gpu{#GPUTEMP}: temperature is too high: {ITEM.LASTVALUE}</name>
+                            <expression>{Template mini-IPMI v2:mini.gpu.temp[gpu{#GPUTEMP}].last()}&gt;{$GPU.HIGH.TEMP}</expression>
+                            <name>gpu{#GPUTEMP}: temperature is too high (over {$GPU.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description>(depending on values from last 500 seconds)</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.temp[gpu{#GPUTEMP}].max(24h)}&gt;70</expression>
-                            <name>gpu{#GPUTEMP}: temperature was above 70C within past 24 hours</name>
+                            <expression>{Template mini-IPMI v2:mini.gpu.temp[gpu{#GPUTEMP}].max(24h)}&gt;{$GPU.HIGH.TEMP}</expression>
+                            <name>gpu{#GPUTEMP}: temperature was too high within past 24 hours (over {$GPU.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.gpu.info[gpu{#GPU},ID].diff()}&gt;0</expression>
-                            <name>gpu{#GPU}: GPU model or ID was changed</name>
+                            <name>gpu{#GPU}: GPU model was changed</name>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.info[gpu{#GPU},GPUstatus].str(NO_FAN,#3)}=1</expression>
+                            <expression>{Template mini-IPMI v2:mini.gpu.info[gpu{#GPU},GPUstatus].str(NO_FAN)}=1</expression>
                             <name>gpu{#GPU}: no fan info was found on GPU</name>
                             <url/>
                             <status>1</status>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.gpu.info[gpu{#GPU},GPUstatus].str(NO_TEMP,#3)}=1</expression>
+                            <expression>{Template mini-IPMI v2:mini.gpu.info[gpu{#GPU},GPUstatus].str(NO_TEMP)}=1</expression>
                             <name>gpu{#GPU}: no temperature info was found on GPU</name>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
-                            <description/>
+                            <description>Please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.fan[{#BRDFANNUM},rpm].last(500)}&lt;600</expression>
-                            <name>{#BRDFANNAME}: motherboard fan speed is too low</name>
+                            <expression>{Template mini-IPMI v2:mini.brd.fan[{#BRDFANNUM},rpm].last()}&lt;{$BOARD.FAN.MIN.RPM}</expression>
+                            <name>{#BRDFANNAME}: board fan speed is too low (below {$BOARD.FAN.MIN.RPM} RPM)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
-                            <description>Known false positives (zero speed).</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.temp[{#BRDTEMPNUM}].last(500)}&gt;60</expression>
-                            <name>{#BRDTEMPNAME}: motherboard temperature is too high: {ITEM.LASTVALUE}</name>
+                            <expression>{Template mini-IPMI v2:mini.brd.temp[{#BRDTEMPNUM}].last()}&gt;{$BOARD.HIGH.TEMP}</expression>
+                            <name>{#BRDTEMPNAME}: board temperature is too high (over {$BOARD.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description>(depending on values from last 500 seconds)</description>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.temp[{#BRDTEMPNUM}].max(24h)}&gt;60</expression>
-                            <name>{#BRDTEMPNAME}: motherboard temperature was above 60C within past 24 hours</name>
+                            <expression>{Template mini-IPMI v2:mini.brd.temp[{#BRDTEMPNUM}].max(24h)}&gt;{$BOARD.HIGH.TEMP}</expression>
+                            <name>{#BRDTEMPNAME}: board temperature was too high within past 24 hours (over {$BOARD.HIGH.TEMP} C)</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].last(500)}&gt;5.5</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].last()}&gt;5.5</expression>
                             <name>{#P5V}: voltage is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].last(500)}&lt;4.5</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].last()}&lt;4.5</expression>
                             <name>{#P5V}: voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].max(24h)}&gt;5.5</expression>
@@ -2613,6 +2618,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P5V}].max(24h)}&lt;4.5</expression>
@@ -2622,24 +2628,27 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].last(500)}&gt;13.8</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].last()}&gt;13.8</expression>
                             <name>{#P12V}: voltage is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].last(500)}&lt;10.2</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].last()}&lt;10.2</expression>
                             <name>{#P12V}: voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].max(24h)}&gt;13.8</expression>
@@ -2649,6 +2658,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P12V}].max(24h)}&lt;10.2</expression>
@@ -2658,24 +2668,27 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].last(500)}&gt;3.6</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].last()}&gt;3.6</expression>
                             <name>{#P33V}: voltage is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].last(500)}&lt;3.0</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].last()}&lt;3.0</expression>
                             <name>{#P33V}: voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].max(24h)}&gt;3.6</expression>
@@ -2685,6 +2698,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#P33V}].max(24h)}&lt;3.0</expression>
@@ -2694,33 +2708,37 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VBAT}].last(500)}&lt;2.7</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VBAT}].last()}&lt;2.7</expression>
                             <name>{#VBAT}: CMOS battery voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].last(500)}&gt;3.6</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].last()}&gt;3.6</expression>
                             <name>{#VCC3V}: voltage is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].last(500)}&lt;3.0</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].last()}&lt;3.0</expression>
                             <name>{#VCC3V}: voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].max(24h)}&gt;3.6</expression>
@@ -2730,6 +2748,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCC3V}].max(24h)}&lt;3.0</expression>
@@ -2739,42 +2758,27 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCORE}].last(500)} &gt; {Template mini-IPMI v2:mini.brd.info[vcoreMax].last()}</expression>
-                            <name>{#VCORE}: CPU voltage is too high</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>3</priority>
-                            <description>Each processor have individual threshold. OHMR usage must be tweaked (mini_ipmi_ohmr.py). Known incorrect measurements.</description>
-                            <type>0</type>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VCORE}].max(24h)} &gt; {Template mini-IPMI v2:mini.brd.info[vcoreMax].last()}</expression>
-                            <name>{#VCORE}: CPU voltage was too high within past 24 hours</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description>Each processor have individual threshold. OHMR usage must be tweaked (mini_ipmi_ohmr.py). Known incorrect measurements.</description>
-                            <type>0</type>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].last(500)}&gt;3.6</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].last()}&gt;3.6</expression>
                             <name>{#VSB3V}: voltage is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].last(500)}&lt;3.0</expression>
+                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].last()}&lt;3.0</expression>
                             <name>{#VSB3V}: voltage is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description/>
+                            <description>Last value: {ITEM.LASTVALUE}</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].max(24h)}&gt;3.6</expression>
@@ -2784,6 +2788,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VSB3V}].max(24h)}&lt;3.0</expression>
@@ -2793,31 +2798,14 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VTT}].last(500)} &gt; {Template mini-IPMI v2:mini.brd.info[vttMax].last()}</expression>
-                            <name>{#VTT}: voltage is too high</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>3</priority>
-                            <description>Each processor have individual threshold. Tweak in mini_ipmi_ohmr.py before use.</description>
-                            <type>0</type>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template mini-IPMI v2:mini.brd.vlt[{#VTT}].max(24h)} &gt; {Template mini-IPMI v2:mini.brd.info[vttMax].last()}</expression>
-                            <name>{#VTT}: voltage was too high within past 24h</name>
-                            <url/>
-                            <status>0</status>
-                            <priority>2</priority>
-                            <description>Each processor have individual threshold. Tweak in mini_ipmi_ohmr.py before use.</description>
-                            <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
                 </discovery_rule>
                 <discovery_rule>
-                    <name>DISK temperature discovery</name>
+                    <name>DISK discovery</name>
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
@@ -2849,6 +2837,50 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                     <lifetime>1</lifetime>
                     <description/>
                     <item_prototypes>
+                        <item_prototype>
+                            <name>{#DISK}: Status</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.disk.info[{#DISK},DriveStatus]</key>
+                            <delay>0</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>2</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Info</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
                         <item_prototype>
                             <name>{#DISK}: Critical disk temperature threshold</name>
                             <type>2</type>
@@ -2886,11 +2918,100 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <inventory_link>0</inventory_link>
                             <applications>
                                 <application>
-                                    <name>mini-IPMI: Temperature thresholds</name>
+                                    <name>mini-IPMI: Thresholds</name>
                                 </application>
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK}: Maximum disk temperature threshold</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.disk.tempMax[{#DISK}]</key>
+                            <delay>0</delay>
+                            <history>14</history>
+                            <trends>30</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Thresholds</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>{#DISK}: Minimum disk temperature threshold</name>
+                            <type>2</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>mini.disk.tempMin[{#DISK}]</key>
+                            <delay>0</delay>
+                            <history>14</history>
+                            <trends>30</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units>C</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications>
+                                <application>
+                                    <name>mini-IPMI: Thresholds</name>
+                                </application>
+                            </applications>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>{#DISK}: Disk temperature</name>
@@ -2934,146 +3055,19 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>{#DISK}: Maximum disk temperature threshold</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.disk.tempMax[{#DISK}]</key>
-                            <delay>0</delay>
-                            <history>14</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Temperature thresholds</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>{#DISK}: Minimum disk temperature threshold</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.disk.tempMin[{#DISK}]</key>
-                            <delay>0</delay>
-                            <history>14</history>
-                            <trends>30</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>C</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Temperature thresholds</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>{#DISK}: Status</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>mini.disk.info[{#DISK},DriveStatus]</key>
-                            <delay>0</delay>
-                            <history>90</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>2</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>mini-IPMI: Info</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(DUMMY_NVME)}=1</expression>
-                            <name>{#DISK}: Assumed to be a placeholder NVMe</name>
+                            <name>{#DISK}: Assumed to be a placeholder NVMe (mini-IPMI)</name>
                             <url/>
                             <status>1</status>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(ERR_CODE_1)}=1</expression>
@@ -3083,54 +3077,64 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(ERR_CODE_2)}=1</expression>
                             <name>{#DISK}: Device open failed (mini-IPMI)</name>
                             <url/>
-                            <status>0</status>
+                            <status>1</status>
                             <priority>1</priority>
                             <description>Probably no administrative permissions for smartctl or incorrect device name.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>({Template mini-IPMI v2:mini.disk.temp[{#DISK}].last()} &gt; {Template mini-IPMI v2:mini.disk.tempCrit[{#DISK}].last()}) and&#13;
 {Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].regexp(^DUPLICATE_IGNORE$|^STANDBY|^SLEEP$)}=0</expression>
-                            <name>{#DISK}: Disk temperature is critical: {ITEM.LASTVALUE}</name>
+                            <name>{#DISK}: Disk temperature is critical</name>
                             <url/>
                             <status>0</status>
                             <priority>4</priority>
-                            <description>If last value is more than critical temperature setting and&#13;
+                            <description>Last value: {ITEM.LASTVALUE}&#13;
+If last value is more than critical temperature setting AND&#13;
 drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>({Template mini-IPMI v2:mini.disk.temp[{#DISK}].last()}  &gt; {Template mini-IPMI v2:mini.disk.tempMax[{#DISK}].last()}) and&#13;
 ({Template mini-IPMI v2:mini.disk.temp[{#DISK}].prev()} &gt; {Template mini-IPMI v2:mini.disk.tempMax[{#DISK}].last()}) and&#13;
 {Template mini-IPMI v2:mini.disk.temp[{#DISK}].count(2h)}&gt;=2 and&#13;
 {Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].regexp(^DUPLICATE_IGNORE$|^STANDBY|^SLEEP$)}=0</expression>
-                            <name>{#DISK}: Disk temperature is too high: {ITEM.LASTVALUE}</name>
+                            <name>{#DISK}: Disk temperature is too high</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description>If last value is more than maximum temperature setting and&#13;
-previous value is more than maximum temperature setting and&#13;
+                            <description>Last value: {ITEM.LASTVALUE}&#13;
+If last value is more than maximum temperature setting AND&#13;
+previous value is more than maximum temperature setting AND&#13;
+there's been at least 2 values in the last 2 hours AND&#13;
 drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>({Template mini-IPMI v2:mini.disk.temp[{#DISK}].last()}  &lt; {Template mini-IPMI v2:mini.disk.tempMin[{#DISK}].last()}) and&#13;
 ({Template mini-IPMI v2:mini.disk.temp[{#DISK}].prev()} &lt; {Template mini-IPMI v2:mini.disk.tempMin[{#DISK}].last()}) and&#13;
-{Template mini-IPMI v2:mini.disk.temp[{#DISK}].count(2h)}&gt;=2 and&#13;
+{Template mini-IPMI v2:mini.disk.temp[{#DISK}].count(2h)}&gt;=3 and&#13;
 {Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].regexp(^DUPLICATE_IGNORE$|^STANDBY|^SLEEP$)}=0</expression>
-                            <name>{#DISK}: Disk temperature is too low: {ITEM.LASTVALUE}</name>
+                            <name>{#DISK}: Disk temperature is too low</name>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
-                            <description>If last value is less than minimum temperature setting and&#13;
-previous value is less than minimum temperature setting and&#13;
+                            <description>Last value: {ITEM.LASTVALUE}&#13;
+If last value is less than minimum temperature setting AND&#13;
+previous value is less than minimum temperature setting AND&#13;
+there's been at least 3 values in the last 2 hours AND&#13;
 drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>({Template mini-IPMI v2:mini.disk.temp[{#DISK}].max(24h)} &gt; {Template mini-IPMI v2:mini.disk.tempCrit[{#DISK}].last()}) and&#13;
@@ -3142,6 +3146,7 @@ drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <description>If any value within last 24 hours exceeded critical temperature setting and&#13;
 last drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(NOSENSOR)}=1</expression>
@@ -3151,24 +3156,27 @@ last drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(SLEEP)}=1</expression>
-                            <name>{#DISK}: Is in SLEEP mode</name>
+                            <name>{#DISK}: Is in SLEEP mode (mini-IPMI)</name>
                             <url/>
                             <status>1</status>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(STANDBY)}=1</expression>
-                            <name>{#DISK}: Is in STANDBY mode</name>
+                            <name>{#DISK}: Is in STANDBY mode (mini-IPMI)</name>
                             <url/>
                             <status>1</status>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(NOTEMP)}=1</expression>
@@ -3176,8 +3184,9 @@ last drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <url/>
                             <status>0</status>
                             <priority>1</priority>
-                            <description/>
+                            <description>Take a look at noTemperatureSensorModels variable in the script and please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(ERROR)}=1</expression>
@@ -3187,6 +3196,7 @@ last drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].count(#3,&quot;TIMEOUT&quot;,&quot;eq&quot;)}&gt;=3</expression>
@@ -3196,72 +3206,125 @@ last drive status is not DUPLICATE_IGNORE, STANDBY* or SLEEP.</description>
                             <priority>2</priority>
                             <description>Could indicate disk failure. Investigation is advised.</description>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(UNK_USB_BRIDGE)}=1</expression>
-                            <name>{#DISK}: Unknown USB bridge</name>
+                            <name>{#DISK}: Unknown USB bridge (mini-IPMI)</name>
                             <url/>
                             <status>1</status>
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
                     <host_prototypes/>
                 </discovery_rule>
             </discovery_rules>
-            <macros/>
+            <macros>
+                <macro>
+                    <macro>{$BOARD.FAN.MIN.RPM}</macro>
+                    <value>400</value>
+                </macro>
+                <macro>
+                    <macro>{$BOARD.HIGH.TEMP}</macro>
+                    <value>60</value>
+                </macro>
+                <macro>
+                    <macro>{$CPU.HIGH.TEMP}</macro>
+                    <value>60</value>
+                </macro>
+                <macro>
+                    <macro>{$EXPECTED.BIOS.VERS}</macro>
+                    <value>^4001$|^0508$|^P1\.90$|^0601$|^1801$|^V2\.7$</value>
+                </macro>
+                <macro>
+                    <macro>{$EXPECTED.OHMR.VERS}</macro>
+                    <value>^0\.8\.0\.5$|^0\.3\.2\.0$</value>
+                </macro>
+                <macro>
+                    <macro>{$GPU.FAN.MIN.RPM}</macro>
+                    <value>400</value>
+                </macro>
+                <macro>
+                    <macro>{$GPU.HIGH.TEMP}</macro>
+                    <value>70</value>
+                </macro>
+                <macro>
+                    <macro>{$GPU.MIN.MEM.MB}</macro>
+                    <value>32</value>
+                </macro>
+            </macros>
             <templates/>
             <screens/>
         </template>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.disk.temp[MAX].last(500)}&gt;46</expression>
-            <name>Disk temperature is too high</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCMD)}=1</expression>
+            <name>CPU binary was not found in PATH or manually (mini-IPMI)</name>
+            <url/>
+            <status>0</status>
+            <priority>1</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template mini-IPMI v2:mini.cpu.temp[MAX].last()}&gt;{$CPU.HIGH.TEMP}</expression>
+            <name>CPU temperature is too high (over {$CPU.HIGH.TEMP} C)</name>
             <url/>
             <status>1</status>
             <priority>3</priority>
-            <description>(depending on values from last 500 seconds)&#13;
-This one is disabled - individual disk trigger takes precedence.</description>
+            <description>Last value: {ITEM.LASTVALUE}</description>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template mini-IPMI v2:mini.cpu.temp[MAX].max(24h)}&gt;{$CPU.HIGH.TEMP}</expression>
+            <name>CPU temperature was too high in past 24 hours (over {$CPU.HIGH.TEMP} C)</name>
+            <url/>
+            <status>1</status>
+            <priority>2</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template mini-IPMI v2:mini.disk.temp[MAX].last()}&gt;46</expression>
+            <name>DISK temperature is too high</name>
+            <url/>
+            <status>1</status>
+            <priority>3</priority>
+            <description>Last value: {ITEM.LASTVALUE}</description>
             <type>0</type>
             <dependencies/>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.temp[MAX].max(24h)}&gt;46</expression>
-            <name>Disk temperature was too high in past 24 hours</name>
+            <name>DISK temperature was too high in past 24 hours</name>
             <url/>
             <status>1</status>
             <priority>2</priority>
-            <description>(depending on values from last day)&#13;
-This one is disabled - individual disk trigger takes precedence.</description>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCMD,#3)}=1</expression>
-            <name>mini-IPMI: CPU binary was not found in PATH or manually</name>
-            <url/>
-            <status>0</status>
-            <priority>1</priority>
             <description/>
             <type>0</type>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUS,#3)}=1</expression>
-            <name>mini-IPMI: no CPUs were found for temperature test</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUS)}=1</expression>
+            <name>No CPUs were found for temperature test (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
-            <description/>
+            <description>Please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
             <type>0</type>
             <dependencies/>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[ConfigStatus].str(NODISKS)}=1</expression>
-            <name>mini-IPMI: no DISKs were found for temperature test</name>
+            <name>No DISKs were found for temperature test (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3270,8 +3333,8 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOGPUS,#3)}=1</expression>
-            <name>mini-IPMI: no GPUs were found for temperature test</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOGPUS)}=1</expression>
+            <name>No GPUs were found for temperature test (mini-IPMI)</name>
             <url/>
             <status>1</status>
             <priority>1</priority>
@@ -3280,10 +3343,10 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUTEMPS,4d)}=1</expression>
-            <name>mini-IPMI: no temperatures were found among CPUs</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOCPUTEMPS)}=1</expression>
+            <name>No temperatures was found among CPUs (mini-IPMI)</name>
             <url/>
-            <status>0</status>
+            <status>1</status>
             <priority>1</priority>
             <description/>
             <type>0</type>
@@ -3291,7 +3354,7 @@ This one is disabled - individual disk trigger takes precedence.</description>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[ConfigStatus].str(NODISKTEMPS)}=1</expression>
-            <name>mini-IPMI: no temperatures were found among DISKs</name>
+            <name>No temperatures was found among DISKs (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3300,8 +3363,8 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOGPUTEMPS,#3)}=1</expression>
-            <name>mini-IPMI: no temperatures were found among GPUs</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(NOGPUTEMPS)}=1</expression>
+            <name>No temperatures was found among GPUs (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3311,7 +3374,7 @@ This one is disabled - individual disk trigger takes precedence.</description>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[ConfigStatus].str(NOCMD)}=1</expression>
-            <name>mini-IPMI: smartctl was not found in PATH or manually</name>
+            <name>smartctl was not found in PATH or manually (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3320,28 +3383,38 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(ERROR,#3)}=1</expression>
-            <name>mini-IPMI: something went wrong with CPU configuration</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(ERROR)}=1</expression>
+            <name>Something went wrong with CPU configuration (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
+            <description>Ensure you configuration is up to date and please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[SendStatus].str(ERROR,12h)}=1</expression>
+            <name>Something went wrong with CPU sending (mini-IPMI)</name>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
             <description/>
             <type>0</type>
             <dependencies/>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[ConfigStatus].str(ERROR)}=1</expression>
-            <name>mini-IPMI: something went wrong with DISK configuration</name>
+            <name>Something went wrong with DISK configuration (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
-            <description/>
+            <description>Ensure you configuration is up to date and please report: https://github.com/nobodysu/zabbix-mini-IPMI/issues</description>
             <type>0</type>
             <dependencies/>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[SendStatus].str(ERROR,12h)}=1</expression>
-            <name>mini-IPMI: something went wrong with DISK sending</name>
+            <name>Something went wrong with DISK sending (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>2</priority>
@@ -3351,7 +3424,7 @@ This one is disabled - individual disk trigger takes precedence.</description>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].nodata(7d)}=1</expression>
-            <name>mini-IPMI: template is assigned, but no CPU data is recieved</name>
+            <name>Template is assigned, but no CPU data recieved (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3361,7 +3434,7 @@ This one is disabled - individual disk trigger takes precedence.</description>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[ConfigStatus].nodata(7d)}=1</expression>
-            <name>mini-IPMI: template is assigned, but no DISK data is recieved</name>
+            <name>Template is assigned, but no DISK data recieved (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>1</priority>
@@ -3370,8 +3443,8 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.cpu.info[ConfigStatus].str(HUGEDATA,#3)}=1</expression>
-            <name>mini-IPMI: too much data for CPU sending</name>
+            <expression>{Template mini-IPMI v2:mini.cpu.info[SendStatus].str(HUGEDATA,12h)}=1</expression>
+            <name>Too much data for CPU sending (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>2</priority>
@@ -3381,7 +3454,7 @@ This one is disabled - individual disk trigger takes precedence.</description>
         </trigger>
         <trigger>
             <expression>{Template mini-IPMI v2:mini.disk.info[SendStatus].str(HUGEDATA,12h)}=1</expression>
-            <name>mini-IPMI: too much data for DISK sending</name>
+            <name>Too much data for DISK sending (mini-IPMI)</name>
             <url/>
             <status>0</status>
             <priority>2</priority>
@@ -3390,12 +3463,22 @@ This one is disabled - individual disk trigger takes precedence.</description>
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template mini-IPMI v2:mini.brd.info[BIOSversion].regexp(^4001$|^0508$|^P1.90$|^0601$|^1801$|^V2.7$)}=0</expression>
-            <name>Unexpected BIOS firmware version: {ITEM.LASTVALUE}</name>
+            <expression>{Template mini-IPMI v2:mini.brd.info[BIOSversion].regexp({$EXPECTED.BIOS.VERS})}=0</expression>
+            <name>Unexpected BIOS firmware version (mini-IPMI)</name>
             <url/>
-            <status>1</status>
+            <status>0</status>
             <priority>1</priority>
-            <description>List of newest BIOS firmware versions on the clients.</description>
+            <description>Last value: {ITEM.LASTVALUE}</description>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template mini-IPMI v2:mini.info[OHMRversion].regexp({$EXPECTED.OHMR.VERS})}=0</expression>
+            <name>Unexpected OHMR version</name>
+            <url/>
+            <status>0</status>
+            <priority>1</priority>
+            <description>Last value: {ITEM.LASTVALUE}</description>
             <type>0</type>
             <dependencies/>
         </trigger>

--- a/Template_mini-IPMI_v2.xml
+++ b/Template_mini-IPMI_v2.xml
@@ -3083,7 +3083,7 @@ Could refer to mini_ipmi_lmsensors.py, mini_ipmi_ohmr.py or mini_ipmi_bsdcpu.py.
                             <expression>{Template mini-IPMI v2:mini.disk.info[{#DISK},DriveStatus].str(ERR_CODE_2)}=1</expression>
                             <name>{#DISK}: Device open failed (mini-IPMI)</name>
                             <url/>
-                            <status>1</status>
+                            <status>0</status>
                             <priority>1</priority>
                             <description>Probably no administrative permissions for smartctl or incorrect device name.</description>
                             <type>0</type>

--- a/Win/mini_ipmi_ohmr.py
+++ b/Win/mini_ipmi_ohmr.py
@@ -307,8 +307,9 @@ def getBoardTemps(pOut_):
     for name, val, id in tempsRe:
         name = name.strip()
         
-        if (isCpuSensorPresent(pOut_) and
-            name == 'CPU Core'):
+        if  (isCpuSensorPresent(pOut_) and
+             re.match('^CPU Core$|^CPU$', name)):
+            
             continue
 
         ignoredSensor = False

--- a/Win/mini_ipmi_ohmr.py
+++ b/Win/mini_ipmi_ohmr.py
@@ -2,69 +2,104 @@
 
 ## Installation instructions: https://github.com/nobodysu/zabbix-mini-IPMI ##
 
-#binPath = r'OpenHardwareMonitorReport.exe'
-binPath = r'C:\distr\OpenHardwareMonitorReport\OpenHardwareMonitorReport.exe'   # if OHMR isn't in PATH
+#BIN_PATH = r'OpenHardwareMonitorReport.exe'
+BIN_PATH = r'C:\distr\OpenHardwareMonitorReport\OpenHardwareMonitorReport.exe'   # if OHMR isn't in PATH
 
-# path to second send script
-senderPyPath = r'C:\zabbix-agent\scripts\sender_wrapper.py'
+# path to send script
+SENDER_WRAPPER_PATH = r'C:\zabbix-agent\scripts\sender_wrapper.py'
 
 # path to zabbix agent configuration file
-agentConf = r'C:\zabbix_agentd.conf'
+AGENT_CONF_PATH = r'C:\zabbix_agentd.conf'
 
-#senderPath = r'zabbix_sender'
-senderPath = r'C:\zabbix-agent\bin\win32\zabbix_sender.exe'
+#SENDER_PATH = r'zabbix_sender'
+SENDER_PATH = r'C:\zabbix-agent\bin\win32\zabbix_sender.exe'
 
-timeout = '80'              # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
+PARAMS = 'reporttoconsole --IgnoreMonitorHDD --IgnoreMonitorRAM'
+# Possible params:
+# --IgnoreMonitorCPU
+# --IgnoreMonitorFanController
+# --IgnoreMonitorGPU
+# --IgnoreMonitorHDD
+# --IgnoreMonitorMainboard
+# --IgnoreMonitorRAM
+
+SKIP_PARAMS_ON_WINXP = True    # True or False
+
+# Advanced configuration
+
+# Supply absent Tjmax
+MANUAL_TJMAXES = (
+    ('AMD Athlon 64 X2 Dual Core Processor 5200+',  '72'),
+)
+
+# Ignore specific temperature by name on specific board
+IGNORED_SENSORS = (
+    ('H110M-R',           'Temperature #6'),          # ignore 'Temperature #6' on board 'H110M-R'
+#   ('EXAMPLE_BOARDNAME', 'EXAMPLE_TEMPERATURENAME'),
+#   ('Pull requests',     'are welcome'),
+)
+
+# These CPUs will produce NO_SENSOR trigger instead of NO_TEMP
+CPUS_WITHOUT_SENSOR = (
+    'Intel Pentium 4 3.00GHz',
+)
+
+BOARD_REGEXPS_AND_KEYS = (
+    ('^SMBIOS\s+Version:\s+(.+)$',          'mini.brd.info[SMBIOSversion]'),
+    ('^BIOS\s+Vendor:\s+(.+)$',             'mini.brd.info[BIOSvendor]'),
+    ('^BIOS\s+Version:\s+(.+)$',            'mini.brd.info[BIOSversion]'),
+    ('^Mainboard\s+Manufacturer:\s+(.+)$',  'mini.brd.info[MainboardManufacturer]'),
+    ('^Mainboard\s+Name:\s+(.+)$',          'mini.brd.info[MainboardName]'),
+    ('^Mainboard\s+Version:\s+(.+)$',       'mini.brd.info[MainboardVersion]'),
+)
+
+VOLTAGE_REGEXPS_KEYS_AND_JSONS = (
+    ('^VCore$',                             'cpuVcore', '{#VCORE}'),
+    ('^VBAT$',                              'VBat',     '{#VBAT}'),
+    ('(^3VSB$|^VSB3V$|^Standby \+3\.3V$)',  'VSB3V',    '{#VSB3V}'),
+    ('(^3VCC$|^VCC3V$)',                    'VCC3V',    '{#VCC3V}'),
+    ('^AVCC$',                              'AVCC',     '{#VAVCC}'),
+    ('^VTT$',                               'VTT',      '{#VTT}'),
+)
+
+TIMEOUT = '80'              # how long the script must wait between LLD and sending, increase if data received late (does not affect windows)
                             # this setting MUST be lower than 'Update interval' in discovery rule
-
-fallbackTjmax = '70'        # this value will be set to 'mini.cpu.info[cpu{#CPU},TjMax]' when it's not found on processor or in manualThresholds
-fallbackVcoremax = '1.35'   # maximum allowed voltage for system processor, board-wide
-vttMax = '1.1'              # processor-specific maximum VTT, board-wide
-
-# Predefined sets of Vcore maximum voltages and TjMax. Corresponds to 'mini.brd.info[vcoreMax]' and 'mini.cpu.info[cpu{#CPU},TjMax]' items.
-# All numeric values must be quoted. '%ANY%' will work only in board name field. 'None' will try to aquire values from output and 'fallbackTjmax'. 
-# TjMax comparison will try to match cpu only. Vcore comparison will try to match board and cpu. Especially useful in case of incorrect multipliers.
-
-manualThresholds = ( # Exact 'MainboardName' #    # Exact 'cpu{#CPU},TjMax' #                    # Vcore max voltage #    # TjMax #
-                    ('M3N78-VM',                  'AMD Athlon 64 X2 Dual Core Processor 5200+',  '1.42',                  '72'),   # on board 'M3N78-VM' with cpu 'AMD Athlon 64 X2 Dual Core Processor 5200+' key 'mini.brd.info[vcoreMax]' will be set to '1.42'. 'mini.cpu.info[cpu{#CPU},TjMax]' will be set to '72' regardless of board name
-                    ('P5KPL-AM IN/ROEM/SI',       'Intel Core 2 Duo E7500',                      '1.9',                   None),   # on board 'P5KPL-AM IN/ROEM/SI' with cpu 'Intel Core 2 Duo E7500' key 'mini.brd.info[vcoreMax]' will be set to '1.9'. 'mini.cpu.info[cpu{#CPU},TjMax]' will be queried from output and fallbackTjmax as last resort
-                    ('%ANY%',                     'Intel Pentium 4 3.00GHz',                     '1.37',                  None),   # on any board with cpu 'Intel Pentium 4 3.00GHz' key 'mini.brd.info[vcoreMax]' will be set to '1.36' and 'mini.cpu.info[cpu{#CPU},TjMax]' will be set to fallbackTjmax (as there's no sensor on this cpu)
-                   )
-
-ignoreBoardTemp =  (
-                    ('H110M-R',           'Temperature #6'),          # ignore 'Temperature #6' on board 'H110M-R' (readings from mars)
-                  # ('EXAMPLE_BOARDNAME', 'EXAMPLE_TEMPERATURENAME'),
-                  # ('Pull requests',     'are welcome'),
-                   )
-
-# Following settings brings (almost) no overhead. Use 'no' to disable unneeded data.
-gatherBoardFans = 'yes'
-gatherBoardTemp = 'yes'
-gatherVoltages =  'yes'
-gatherCpuData =   'yes'
-gatherGpuData =   'yes'
 
 ## End of configuration ##
 
 import sys
 import subprocess
 import re
-from sender_wrapper import (readConfig, processData, fail_ifNot_Py3)
+import platform
+from sender_wrapper import (readConfig, processData, fail_ifNot_Py3, removeQuotes)
+
+HOST = sys.argv[2]
 
 
-def getOutput():
+def chooseCmd(binPath_, params_):
+
+    cmd = '%s %s' % (binPath_, params_)
+
+    if not SKIP_PARAMS_ON_WINXP:
+        if platform.release() == "XP":
+            cmd = binPath_
+    
+    return cmd
+    
+
+def getOutput(cmd_):
     p = None
     try:
-        p = subprocess.check_output([binPath], universal_newlines=True)
+        p = subprocess.check_output(cmd_, universal_newlines=True)
     except OSError as e:
         if e.args[0] == 2:
-            error = 'OS_NOCMD'
+            status = 'OS_NOCMD'
         else:
-            error = 'OS_ERROR'
+            status = 'OS_ERROR'
             if sys.argv[1] == 'getverb':
                 raise
     except Exception as e:
-        error = 'UNKNOWN_EXC_ERROR'
+        status = 'UNKNOWN_EXC_ERROR'
 
         if sys.argv[1] == 'getverb':
             raise
@@ -74,331 +109,363 @@ def getOutput():
         except:
             pass
     else:
-        error = 'CONFIGURED'
+        status = 'CONFIGURED'
 
     # Prevent empty results
-    m0 = 'Status: Extracting driver failed'
-    m1 = 'First Exception: OpenSCManager returned zero.'
-    m2 = 'Second Exception: OpenSCManager returned zero.'
-    if m0 in p or \
-       m1 in p or \
-       m2 in p:
-        print('OHMR failed. Try again.')
-        sys.exit(1)
+    if p:
+        m0 = 'Status: Extracting driver failed'
+        m1 = 'First Exception: OpenSCManager returned zero.'
+        m2 = 'Second Exception: OpenSCManager returned zero.'
+        if    (m0 in p or
+               m1 in p or
+               m2 in p):
+               
+            print('OHMR failed. Try again.')
+            sys.exit(1)
 
-    return error, p
+    return status, p
 
 
-def getBoardInfo():
-    sender = []
+def getOHMRversion(pOut_):
 
-    OHMRver = re.search(r'^Version:\s+(.+)$', pOut, re.I | re.M)
+    OHMRver = re.search(r'^Version:\s+(.+)$', pOut_, re.I | re.M)
     if OHMRver:
-        sender.append(host + ' mini.info[OHMRver] "' + OHMRver.group(1).strip() + '"')
-
-    SMBIOS = re.search(r'^SMBIOS\s+Version:\s+(.+)$', pOut, re.I | re.M)
-    if SMBIOS:
-        sender.append(host + ' mini.brd.info[SMBIOSversion] "' + SMBIOS.group(1).strip() + '"')
-
-    BIOSvendor = re.search(r'^BIOS\s+Vendor:\s+(.+)$', pOut, re.I | re.M)
-    if BIOSvendor:
-        sender.append(host + ' mini.brd.info[BIOSvendor] "' + BIOSvendor.group(1).strip() + '"')
-
-    BIOSver = re.search(r'^BIOS\s+Version:\s+(.+)$', pOut, re.I | re.M)
-    if BIOSver:
-        sender.append(host + ' mini.brd.info[BIOSversion] "' + BIOSver.group(1).strip() + '"')
-
-    boardManuf = re.search(r'^Mainboard\s+Manufacturer:\s+(.+)$', pOut, re.I | re.M)
-    if boardManuf:
-        sender.append(host + ' mini.brd.info[MainboardManufacturer] "' + boardManuf.group(1).strip() + '"')
-
-    boardNameRe = re.search(r'^Mainboard\s+Name:\s+(.+)$', pOut, re.I | re.M)
-    if boardNameRe:
-        sender.append(host + ' mini.brd.info[MainboardName] "' + boardNameRe.group(1).strip() + '"')
-
-    boardVersion = re.search(r'^Mainboard\s+Version:\s+(.+)$', pOut, re.I | re.M)
-    if boardVersion:
-        sender.append(host + ' mini.brd.info[MainboardVersion] "' + boardVersion.group(1).strip() + '"')
-
-    return sender, boardNameRe.group(1).strip()
-
-
-def getVoltages():
-    '''Tries to get motherboard voltages.'''
-    sender = []
-    json = []
-
-    voltages = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+\.\d+|\d+)\s+.+\(\/lpc\/[\w-]+\/voltage\/(\d+)\)', pOut, re.I)   # slightly loose
-
-    for i in voltages:
-
-        if re.search('VCore', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[cpuVcore] "' + i[1] + '"')
-            json.append({'{#VCORE}':'cpuVcore'})   # hardcoded because of zabbix stubbornness
-
-        elif re.match('VBAT', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[VBat] "' + i[1] + '"')
-            json.append({'{#VBAT}':'VBat'})
-
-        elif re.match('3VSB', i[0], re.I) or re.match('VSB3V', i[0], re.I) or re.match(r'Standby \+3\.3V', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[VSB3V] "' + i[1] + '"')
-            json.append({'{#VSB3V}':'VSB3V'})
-
-        elif re.match('3VCC', i[0], re.I) or re.match('VCC3V', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[VCC3V] "' + i[1] + '"')
-            json.append({'{#VCC3V}':'VCC3V'})
-
-        elif re.match('AVCC', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[AVCC] "' + i[1] + '"')
-            json.append({'{#VAVCC}':'AVCC'})
-
-        elif re.match('VTT', i[0], re.I):
-            sender.append(host + ' mini.brd.vlt[VTT] "' + i[1] + '"')
-            json.append({'{#VTT}':'VTT'})
-
-            sender.append(host + ' mini.brd.info[vttMax] "' + vttMax + '"')
-
-        sender.append(host + ' mini.brd.vlt[' + i[2] + '] "' + i[1] + '"')   # static items for graph, could be duplicate
-
-    return sender, json
-
-
-def getBoardFans():
-    sender = []
-    json = []
-
-    fans = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+).+\(\/lpc\/[\w-]+\/fan\/(\d+)\)', pOut, re.I)
-    for i in fans:
-        k = i[0].strip()
-
-        # only create LLD when speed is not zero, BUT always send zero values (hides phantom fans)
-        sender.append(host + ' mini.brd.fan[' + i[2] + ',rpm] "' + i[1] + '"')
-        if i[1] != '0':
-            json.append({'{#BRDFANNAME}':k, '{#BRDFANNUM}':i[2]})
-
-    return sender, json
-
-
-def getBoardTemp(currentBoard):
-    sender = []
-    json = []
-
-    temps = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+).+\(\/lpc\/[\w-]+\/temperature\/(\d+)\)', pOut, re.I)
-
-    allTemps = []
-    for i in temps:
-        temperatureName = i[0].strip()
-
-        ignoredSensor = False
-        if currentBoard:
-            for boardReference, ignoredTemp in ignoreBoardTemp:
-                if boardReference == currentBoard and ignoredTemp == temperatureName:
-                    ignoredSensor = True
-
-        if ignoredSensor:
-            continue   # ignore iterated sensor if its found in configuration
-
-        allTemps.append(int(i[1]))
-
-        sender.append(host + ' mini.brd.temp[' + i[2] + '] "' + i[1] + '"')
-        json.append({'{#BRDTEMPNAME}':temperatureName, '{#BRDTEMPNUM}':i[2]})
-
-    if allTemps:
-        sender.append(host + ' mini.brd.temp[MAX] "' + str(max(allTemps)) + '"')
-
-    return sender, json
-
-
-def getGpuData():
-    sender = []
-    json = []
-
-    # determine available GPUs
-    gpus = re.findall(r'\+\-\s+(.+)\s+\(\/[\w-]+gpu\/(\d+)\)', pOut, re.I)
-    gpus = set(gpus)   # remove duplicates
-
-    allTemps = []
-    for i in gpus:
-        errors = []
-        sender.append(host + ' mini.gpu.info[gpu' + i[1] + ',ID] "' + i[0].strip() + '"')
-        json.append({'{#GPU}':i[1]})
-
-        temp = re.search(r':\s+(\d+).+\(\/[\w-]+gpu\/' + i[1] + '\/temperature\/0\)', pOut, re.I)
-        if temp:
-            json.append({'{#GPUTEMP}':i[1]})
-            allTemps.append(int(temp.group(1)))
-            sender.append(host + ' mini.gpu.temp[gpu' + i[1] + '] "' + temp.group(1) + '"')
-        else:
-            errors.append('NO_TEMP')
-
-        fanspeed = re.search(r':\s+(\d+).+\(\/[\w-]+gpu\/' + i[1] + '\/fan\/0\)', pOut, re.I)
-        if fanspeed:
-            sender.append(host + ' mini.gpu.fan[gpu' + i[1] + ',rpm] "' + fanspeed.group(1) + '"')
-            if fanspeed.group(1) != '0':
-                json.append({'{#GPUFAN}':i[1]})
-        else:
-            errors.append('NO_FAN')
-
-        memory = re.findall(r'\+\-\s+(GPU\s+Memory\s+Free|GPU\s+Memory\s+Used|GPU\s+Memory\s+Total)\s+:\s+(\d+).+\(\/[\w-]+gpu\/' + i[1] + '\/smalldata\/\d+\)', pOut, re.I)
-        if memory:
-            json.append({'{#GPUMEM}':i[1]})
-            for m in memory:   # more controllable
-                if 'Free' in m[0]:
-                    sender.append(host + ' mini.gpu.memory[gpu' + i[1] + ',free] "' + m[1] + '"')
-                elif 'Used' in m[0]:
-                    sender.append(host + ' mini.gpu.memory[gpu' + i[1] + ',used] "' + m[1] + '"')
-                elif 'Total' in m[0]:
-                    sender.append(host + ' mini.gpu.memory[gpu' + i[1] + ',total] "' + m[1] + '"')
-
-        if errors:
-            for e in errors:
-                sender.append(host + ' mini.gpu.info[gpu' + i[1] + ',GPUstatus] "' + e + '"')   # NO_TEMP, NO_FAN
-        else:
-            sender.append(host + ' mini.gpu.info[gpu' + i[1] + ',GPUstatus] "PROCESSED"')
-
-    if gpus:
-        if allTemps:
-            error = None
-            sender.append(host + ' mini.gpu.temp[MAX] "' + str(max(allTemps)) + '"')
-        else:
-            error = 'NOGPUTEMPS'
+        version = OHMRver.group(1).strip()
     else:
-        error = 'NOGPUS'
+        version = None
+        
+    sender = ['"%s" mini.info[OHMRversion] "%s"' % (HOST, removeQuotes(version))]
+        
+    return sender
+    
+    
+def getBoardInfo(pOut_):
 
-    return sender, json, error
+    sender = []
 
+    for regexp, key in BOARD_REGEXPS_AND_KEYS:
+        reMatch = re.search(regexp, pOut_, re.I | re.M)
+        if reMatch:
+            sender.append('"%s" %s "%s"' % (HOST, key, removeQuotes(reMatch.group(1).strip())))
 
-def getTjmaxAndVcoremax(currentBoard, currentCpuID, currentCpuName):
-    gotTjmax = False
-    gotVcoremax = False
-    for board, cpu, vcoremax, tjmax in manualThresholds:
-        if board and cpu:                   # if values are not empty
-            if board == currentBoard or \
-               board == '%ANY%':            # board was found in threshholds
-
-                # Board and CPU comparison
-                if cpu == currentCpuName:    # cpu was found in threshholds
-                    if vcoremax:
-                        resultVcoremax = vcoremax
-                        gotVcoremax = True
-
-        # CPU-only comparison
-        if cpu:
-            if cpu == currentCpuName:
-                if tjmax:
-                    resultTjmax = tjmax
-                    gotTjmax = True
-
-    if not gotTjmax:
-        tjMaxRe = re.search(r'\(\/[\w-]+cpu\/' + currentCpuID + '\/temperature\/\d+\)\s+\|\s+\|\s+\+\-\s+TjMax\s+\[\S+\]\s+:\s+(\d+)', pOut, re.I | re.M)
-        if tjMaxRe:
-            resultTjmax = tjMaxRe.group(1)
-        else:
-            resultTjmax = fallbackTjmax
-
-    if not gotVcoremax:
-        resultVcoremax = fallbackVcoremax
-
-    return resultTjmax, resultVcoremax
+    return sender
 
 
-def getCpuData(currentBoard):
+def getBoardName(pOut_):
+
+    boardRe = re.search(r'^Mainboard\s+Name:\s+(.+)$', pOut_, re.I | re.M)
+    if boardRe:
+        board = boardRe.group(1).strip()
+    else:
+        board = None
+
+    return board
+    
+    
+def getTjmax(pOut_, cpuID_, cpuName_):
+    
+    tjMaxRe = re.search(r'\(\/[\w-]+cpu\/%s\/temperature\/\d+\)\s+\|\s+\|\s+\+\-\s+TjMax\s+\[\S+\]\s+:\s+(\d+)' % cpuID_, pOut_, re.I | re.M)
+    if tjMaxRe:
+        tjmax = tjMaxRe.group(1)
+    else:
+        tjmax = None
+        for name, val in MANUAL_TJMAXES:
+            if name == cpuName_:
+                tjmax = val
+                break
+
+    return tjmax
+    
+    
+def isCpuWithoutSensor(cpuname_):
+
+    if cpuname_ in CPUS_WITHOUT_SENSOR:
+        result = True
+    else:
+        result = False
+
+    return result
+    
+    
+def isCpuSensorPresent(pOut_):
+
+    coreTempsRe = re.search(r'Core.+:\s+\d+.+\(\/[\w-]+cpu\/\d+\/temperature\/\d+\)', pOut_, re.I)
+    if coreTempsRe:
+        result = True
+    else:
+        result = False
+
+    return result
+    
+    
+def isParamIgnored(param_):
+
+    if param_ in PARAMS:
+        result = True
+    else:
+        result = False
+        
+    return result
+    
+    
+def getCpusData(pOut_):
+
     sender = []
     json = []
 
     # determine available CPUs
-    CPUs = re.findall(r'\+\-\s+(.+)\s+\(\/[\w-]+cpu\/(\d+)\)', pOut, re.I)
-    CPUs = set(CPUs)   # remove duplicates
+    cpusRe = re.findall(r'\+\-\s+(.+)\s+\(\/[\w-]+cpu\/(\d+)\)', pOut_, re.I)
+    cpus = set(cpusRe)
+    #print(cpusRe)
 
     allTemps = []
-    for cpu in CPUs:
+    for name, id in cpus:
         # Processor model
-        sender.append(host + ' mini.cpu.info[cpu' + cpu[1] + ',ID] "' + cpu[0].strip() + '"')
-        json.append({'{#CPU}':cpu[1]})
+        sender.append('"%s" mini.cpu.info[cpu%s,ID] "%s"' % (HOST, id, removeQuotes(name.strip())))
+        json.append({'{#CPU}':id})
 
-        getTjmaxAndVcoremax_Out = getTjmaxAndVcoremax(currentBoard, cpu[1], cpu[0])
-        sender.append('%s mini.cpu.info[cpu%s,TjMax] "%s"' % (host, cpu[1], getTjmaxAndVcoremax_Out[0]))
-        sender.append('%s mini.brd.info[vcoreMax] "%s"' % (host, getTjmaxAndVcoremax_Out[1]))   # same results for multiple cpus
+        gotTjmax = getTjmax(pOut_, id, name)
+        if gotTjmax:
+            sender.append('"%s" mini.cpu.info[cpu%s,TjMax] "%s"' % (HOST, id, gotTjmax))
 
         # All core temperatures for given CPU
-        coreTempsRe = re.findall(r'Core.+:\s+(\d+).+\(\/[\w-]+cpu\/' + cpu[1] + '\/temperature\/(\d+)\)', pOut, re.I)
+        coreTempsRe = re.findall(r'Core.+:\s+(\d+).+\(\/[\w-]+cpu\/%s\/temperature\/(\d+)\)' % id, pOut_, re.I)
         if coreTempsRe:
-            sender.append(host + ' mini.cpu.info[cpu' + cpu[1] + ',CPUstatus] "PROCESSED"')
+            sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "PROCESSED"' % (HOST, id))
             cpuTemps = []
-            for core in coreTempsRe:
-                cpuTemps.append(int(core[0]))
-                allTemps.append(int(core[0]))
-                sender.append(host + ' mini.cpu.temp[cpu' + cpu[1] + ',core' + core[1] + '] "' + core[0] + '"')
-                json.append({'{#CPUC}':cpu[1], '{#CORE}':core[1]})
+            for coretemp, coreid in coreTempsRe:
+                cpuTemps.append(int(coretemp))
+                allTemps.append(int(coretemp))
+                sender.append('"%s" mini.cpu.temp[cpu%s,core%s] "%s"' % (HOST, id, coreid, coretemp))
+                json.append({'{#CPUC}':id, '{#CORE}':coreid})
 
-            sender.append(host + ' mini.cpu.temp[cpu' + cpu[1] + ',MAX] "' + str(max(cpuTemps)) + '"')
+            sender.append('"%s" mini.cpu.temp[cpu%s,MAX] "%s"' % (HOST, id, str(max(cpuTemps))))
+
+        elif isCpuWithoutSensor(name):
+            sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "NO_SENSOR"' % (HOST, id))
         else:
-            sender.append(host + ' mini.cpu.info[cpu' + cpu[1] + ',CPUstatus] "NO_TEMP"')
+            sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "NO_TEMP"'   % (HOST, id))
 
-    if CPUs:
+    if cpus:
         if allTemps:
             error = None
-            sender.append(host + ' mini.cpu.temp[MAX] "' + str(max(allTemps)) + '"')
+            sender.append('"%s" mini.cpu.temp[MAX] "%s"' % (HOST , str(max(allTemps))))
         else:
             error = 'NOCPUTEMPS'
     else:
         error = 'NOCPUS'
 
     return sender, json, error
+    
+    
+def getVoltages(pOut_):
+
+    sender = []
+    json = []
+
+    voltagesRe = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+\.\d+|\d+)\s+.+\(\/lpc\/[\w-]+\/voltage\/(\d+)\)', pOut_, re.I)
+    for name, val, id in voltagesRe:
+        name = name.strip()
+
+        for regexp, key, jsn in VOLTAGE_REGEXPS_KEYS_AND_JSONS:
+            if re.search(regexp, name, re.I):
+                sender.append('"%s" mini.brd.vlt[%s] "%s"' % (HOST, key, removeQuotes(val)))
+                json.append({jsn:key})
+
+        sender.append('"%s" mini.brd.vlt[%s] "%s"' % (HOST, id, removeQuotes(val)))   # static items for graph, could be duplicate
+
+    return sender, json
+
+
+def getBoardFans(pOut_):
+
+    sender = []
+    json = []
+
+    fansRe = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+).+\(\/lpc\/[\w-]+\/fan\/(\d+)\)', pOut_, re.I)
+    for name, val, num in fansRe:
+        name = name.strip()
+
+        # Only create LLD when speed is not zero, BUT always send zero values (hides phantom fans)
+        sender.append('"%s" mini.brd.fan[%s,rpm] "%s"' % (HOST, num, val))
+        if val != '0':
+            json.append({'{#BRDFANNAME}':name, '{#BRDFANNUM}':num})
+
+    return sender, json
+
+
+def getBoardTemps(pOut_):
+    sender = []
+    json = []
+    
+    board = getBoardName(pOut_)
+
+    tempsRe = re.findall(r'\+\-\s+(.+)\s+:\s+(\d+).+\(\/lpc\/[\w-]+\/temperature\/(\d+)\)', pOut_, re.I)
+    #print(tempsRe)
+
+    allTemps = []
+    for name, val, id in tempsRe:
+        name = name.strip()
+        
+        if (isCpuSensorPresent(pOut_) and
+            name == 'CPU Core'):
+            continue
+
+        ignoredSensor = False
+        if board:
+            for boardReference, ignoredTempName in IGNORED_SENSORS:
+                if      (boardReference == board and
+                         ignoredTempName    == name):
+                    ignoredSensor = True
+
+        if ignoredSensor:
+            continue
+
+        allTemps.append(int(val))
+
+        sender.append('"%s" mini.brd.temp[%s] "%s"' % (HOST, id, val))
+        json.append({'{#BRDTEMPNAME}':name, '{#BRDTEMPNUM}':id})
+
+    if allTemps:
+        sender.append('"%s" mini.brd.temp[MAX] "%s"' % (HOST, str(max(allTemps))))
+
+    return sender, json
+
+
+def getGpusData(pOut_):
+    sender = []
+    json = []
+
+    # Determine available GPUs
+    gpusRe = re.findall(r'\+\-\s+(.+)\s+\(\/[\w-]+gpu\/(\d+)\)', pOut_, re.I)
+    gpus = set(gpusRe)   # remove duplicates
+
+    allTemps = []
+    for name, num in gpus:
+        errors = []
+        sender.append('"%s" mini.gpu.info[gpu%s,ID] "%s"' % (HOST, num, name.strip()))
+        json.append({'{#GPU}':num})
+        
+        temp = re.search(r':\s+(\d+).+\(\/[\w-]+gpu\/%s\/temperature\/0\)' % num, pOut_, re.I)
+        if temp:
+            json.append({'{#GPUTEMP}':num})
+            allTemps.append(int(temp.group(1)))
+            sender.append('"%s" mini.gpu.temp[gpu%s] "%s"' % (HOST, num, temp.group(1)))
+        else:
+            errors.append('NO_TEMP')
+
+        fanspeed = re.search(r':\s+(\d+).+\(\/[\w-]+gpu\/%s\/fan\/0\)' % num, pOut_, re.I)
+        if fanspeed:
+            sender.append('"%s" mini.gpu.fan[gpu%s,rpm] "%s"' % (HOST, num, fanspeed.group(1)))
+            if fanspeed.group(1) != '0':
+                json.append({'{#GPUFAN}':num})
+        else:
+            errors.append('NO_FAN')
+
+        memory = re.findall(r'\+\-\s+(GPU\s+Memory\s+Free|GPU\s+Memory\s+Used|GPU\s+Memory\s+Total)\s+:\s+(\d+).+\(\/[\w-]+gpu\/%s\/smalldata\/\d+\)' % num, pOut_, re.I)
+        if memory:
+            json.append({'{#GPUMEM}':num})
+            for memname, memval in memory:   # more controllable
+                if 'Free' in memname:
+                    sender.append('"%s" mini.gpu.memory[gpu%s,free] "%s"'   % (HOST, num, memval))
+                elif 'Used' in memname:
+                    sender.append('"%s" mini.gpu.memory[gpu%s,used] "%s"'   % (HOST, num, memval))
+                elif 'Total' in memname:
+                    sender.append('"%s" mini.gpu.memory[gpu%s,total] "%s"'  % (HOST, num, memval))
+
+        if errors:
+            for e in errors:
+                sender.append('"%s" mini.gpu.info[gpu%s,GPUstatus] "%s"'    % (HOST, num, e))   # NO_TEMP, NO_FAN
+        else:
+            sender.append('"%s" mini.gpu.info[gpu%s,GPUstatus] "PROCESSED"' % (HOST, num))
+
+    if gpus:
+        if allTemps:
+            statusError = None
+            sender.append('"%s" mini.gpu.temp[MAX] "%s"' % (HOST, str(max(allTemps))))
+        else:
+            statusError = 'NOGPUTEMPS'
+    else:
+        statusError = 'NOGPUS'
+
+    return sender, json, statusError
 
 
 if __name__ == '__main__':
+
     fail_ifNot_Py3()
 
-    host = '"' + sys.argv[2] + '"'
     senderData = []
     jsonData = []
+    statusErrors = []
 
-    getOutput_Out = getOutput()
+    cmd = chooseCmd(BIN_PATH, PARAMS)
+    
+    p_Output = getOutput(cmd)
+    pRunStatus = p_Output[0]
+    pOut = p_Output[1]
+    
+    if pOut:
+        senderData.extend(getOHMRversion(pOut))
+        
+        senderData.extend(getBoardInfo(pOut))
+        
+        if not isParamIgnored('--IgnoreMonitorCPU'):
+            cpuData_Out = getCpusData(pOut)
+            if cpuData_Out:
+                cpuSender = cpuData_Out[0]
+                cpuJson =   cpuData_Out[1]
+                cpuError =  cpuData_Out[2]
+            
+                senderData.extend(cpuSender)
+                jsonData.extend(cpuJson)
+                
+                if cpuError:
+                    statusErrors.append(cpuError)
 
-    statusC = None
-    if getOutput_Out[1]:   # process output
-        pOut = getOutput_Out[1]
-
-        getBoardInfo_Out = getBoardInfo()
-        senderData.extend(getBoardInfo_Out[0])
-        currentBoard = getBoardInfo_Out[1]
-
-        if gatherBoardTemp == 'yes':
-            getBoardTemp_Out = getBoardTemp(currentBoard)
-            senderData.extend(getBoardTemp_Out[0])
-            jsonData.extend(getBoardTemp_Out[1])
-
-        if gatherVoltages == 'yes':
-            getVoltages_Out = getVoltages()
-            senderData.extend(getVoltages_Out[0])
-            jsonData.extend(getVoltages_Out[1])
-
-        if gatherBoardFans == 'yes':
-            getBoardFans_Out = getBoardFans()
-            senderData.extend(getBoardFans_Out[0])
-            jsonData.extend(getBoardFans_Out[1])
-
-        if gatherGpuData == 'yes':
-            getGpuData_Out = getGpuData()
-            senderData.extend(getGpuData_Out[0])
-            jsonData.extend(getGpuData_Out[1])
-            if getGpuData_Out[2]:
-                statusC = 'gpu_err'
-                # mini.cpu.info[ConfigStatus] is used to track configuration states including cpu and gpu:
-                senderData.append(host + ' mini.cpu.info[ConfigStatus] "' + getGpuData_Out[2] + '"')   # NOGPUS, NOGPUTEMPS
-
-        if gatherCpuData == 'yes':
-            getCpuData_Out = getCpuData(currentBoard)
-            senderData.extend(getCpuData_Out[0])
-            jsonData.extend(getCpuData_Out[1])
-            if getCpuData_Out[2]:
-                statusC = 'cpu_err'
-                senderData.append(host + ' mini.cpu.info[ConfigStatus] "' + getCpuData_Out[2] + '"')   # NOCPUS, NOCPUTEMPS (comes after gpu call and can supersede its errors on trigger)
-
-    if not statusC:
-        senderData.append(host + ' mini.cpu.info[ConfigStatus] "' + getOutput_Out[0] + '"')   # OS_NOCMD, OS_ERROR, UNKNOWN_EXC_ERROR, CONFIGURED
-
+        if not isParamIgnored('--IgnoreMonitorMainboard'):
+            boardTemps_Out = getBoardTemps(pOut)
+            if boardTemps_Out:
+                boardSender = boardTemps_Out[0]
+                boardJson =   boardTemps_Out[1]
+                
+                senderData.extend(boardSender)
+                jsonData.extend(boardJson)
+            
+            voltages_Out = getVoltages(pOut)
+            if voltages_Out:
+                voltagesSender = voltages_Out[0]
+                voltagesJson = voltages_Out[1]
+                
+                senderData.extend(voltagesSender)
+                jsonData.extend(voltagesJson)
+        
+        if not isParamIgnored('--IgnoreMonitorFanController'):
+            boardFans_Out = getBoardFans(pOut)
+            if boardFans_Out:
+                senderData.extend(boardFans_Out[0])
+                jsonData.extend(boardFans_Out[1])
+            
+        if not isParamIgnored('--IgnoreMonitorGPU'):
+            gpuData_Out = getGpusData(pOut)
+            if gpuData_Out:
+                gpuSender = gpuData_Out[0]
+                gpuJson =   gpuData_Out[1]
+                gpuError =  gpuData_Out[2]
+                
+                senderData.extend(gpuSender)
+                jsonData.extend(gpuJson)
+                
+                if gpuError:
+                    statusErrors.append(gpuError)
+            
+    if statusErrors:
+        errorsString = ', '.join(statusErrors).strip()
+        senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, errorsString))
+    elif pRunStatus:
+        senderData.append('"%s" mini.cpu.info[ConfigStatus] "%s"' % (HOST, pRunStatus))
+        
     link = r'https://github.com/nobodysu/zabbix-mini-IPMI/issues'
-    processData(senderData, jsonData, agentConf, senderPyPath, senderPath, timeout, host, link)
+    sendStatusKey = 'mini.cpu.info[SendStatus]'
+    processData(senderData, jsonData, AGENT_CONF_PATH, SENDER_WRAPPER_PATH, SENDER_PATH, TIMEOUT, HOST, link, sendStatusKey)
 


### PR DESCRIPTION
- _dropping zabbix24 support_
- switching to special OHMR which could exclude HDDs: https://github.com/openhardwaremonitor/openhardwaremonitor/pull/1115
- disabling non-major triggers to reduce noise
- template tuning via user macro
- max vcore dropped
- max vtt dropped
- complex board and cpu-specific rules dropped
- ryzen support on linux
- fixes #19
- fixes #21
- fixes  #29