### PR TITLE
Try use CPU Package temperature when per core temperature is not avaliable

### DIFF
--- a/Win/mini_ipmi_ohmr.py
+++ b/Win/mini_ipmi_ohmr.py
@@ -244,7 +244,14 @@ def getCpusData(pOut_):
         elif isCpuWithoutSensor(name):
             sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "NO_SENSOR"' % (HOST, id))
         else:
-            sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "NO_TEMP"'   % (HOST, id))
+            packageTempsRe = re.findall(r'Package.+:\s+(\d+).+\(\/[\w-]+cpu\/%s\/temperature\/(\d+)\)' % id, pOut_, re.I)
+            if packageTempsRe:
+                sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "PROCESSED"' % (HOST, id))
+                for packagetemp, packageid in packageTempsRe:
+                    allTemps.append(int(packagetemp))
+
+            else:
+                sender.append('"%s" mini.cpu.info[cpu%s,CPUstatus] "NO_TEMP"'   % (HOST, id))
 
     if cpus:
         if allTemps:


### PR DESCRIPTION
Ryzen and some niche processors didn't support per core temperature report in OHMR but still support package temperature.