### PR TITLE
Fix config path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ server# yum install zabbix-get
 ```bash
 client# mv mini_ipmi_smartctl.py Linux/mini_ipmi_lmsensors.py sender_wrapper.py /etc/zabbix/scripts/
 client# mv Linux/sudoers.d/zabbix /etc/sudoers.d/   # place sudoers include here for mini_ipmi_smartctl.py sudo access
-client# mv Linux/zabbix_agentd.d/userparameter_mini-ipmi2.conf /etc/zabbix/zabbix_agentd.d/
+client# mv Linux/zabbix_agentd.d/userparameter_mini-ipmi2.conf /etc/zabbix/zabbix_agentd.conf.d/
 ```
 
 #### FreeBSD
 ```bash
 client# mv mini_ipmi_smartctl.py BSD/mini_ipmi_bsdcpu.py sender_wrapper.py /etc/zabbix/scripts/
 client# mv BSD/sudoers.d/zabbix /usr/local/etc/sudoers.d/
-client# mv BSD/zabbix_agentd.conf.d/userparameter_mini-ipmi2.conf /usr/local/etc/zabbix/zabbix_agentd.d/
+client# mv BSD/zabbix_agentd.conf.d/userparameter_mini-ipmi2.conf /usr/local/etc/zabbix/zabbix_agentd.conf.d/
 ```
 Then, for Intel processor you need to add `coretemp_load="YES"` to `/boot/loader.conf`. For AMD it will be `amdtemp_load="YES"`. Reboot or manual `kldload` is required to take effect.
 


### PR DESCRIPTION
The installation steps in README mistakenly instruct to copy config to  `/etc/zabbix/zabbix_agentd.d`, while in default configuration (at least in Zabbix 5.0), `/etc/zabbix/zabbix_agentd.conf.d` is used.